### PR TITLE
Refactor load_controlnet to use original loading function & some minor fixes

### DIFF
--- a/control.py
+++ b/control.py
@@ -231,7 +231,7 @@ class ControlNetAdvanced(ControlNet):
                 real_index = keyframe.batch_index
                 # if negative, count from end
                 if real_index < 0:
-                    real_index = latent_count + real_index
+                    real_index += latent_count if self.sub_idxs is None else self.full_latent_length
 
                 # if not mapping indeces, what you see is what you get
                 if mapped_indeces is None:

--- a/control.py
+++ b/control.py
@@ -229,13 +229,17 @@ class ControlNetAdvanced(ControlNet):
                     mapped_indeces[actual] = i
             for keyframe in current_timestep_keyframe.latent_keyframes:
                 real_index = keyframe.batch_index
+                # if negative, count from end
+                if real_index < 0:
+                    real_index = latent_count + real_index
+
                 # if not mapping indeces, what you see is what you get
                 if mapped_indeces is None:
                     if real_index in indeces_to_zero:
-                        indeces_to_zero.remove(keyframe.batch_index)
+                        indeces_to_zero.remove(real_index)
                 # otherwise, see if batch_index is even included in this set of latents
                 else:
-                    real_index = mapped_indeces.get(keyframe.batch_index, None)
+                    real_index = mapped_indeces.get(real_index, None)
                     if real_index is None:
                         continue
                     indeces_to_zero.remove(real_index)

--- a/control.py
+++ b/control.py
@@ -246,13 +246,13 @@ class ControlNetAdvanced(ControlNet):
 
                 # apply strength for each batched cond/uncond
                 for b in range(batched_number):
-                    x[(latent_count*b)+real_index] *= keyframe.strength
+                    x[(latent_count*b)+real_index] = x[(latent_count*b)+real_index] * keyframe.strength
 
             # zero them out by multiplying by zero
             for batch_index in indeces_to_zero:
                 # apply zero for each batched cond/uncond
                 for b in range(batched_number):
-                    x[(latent_count*b)+batch_index] *= 0.0
+                    x[(latent_count*b)+batch_index] = 0.0
 
     def copy(self):
         c = ControlNetAdvanced(self.control_model, self.timestep_keyframes, global_average_pooling=self.global_average_pooling)


### PR DESCRIPTION
Hi, I simplified the `control.py` to reuse original comfy `load_controlnet` instead of rewrite the whole function to reduce maintenance effort. This PR also includes some small other changes:
- Add utility node to setup LatentKeyframe for a batch_index range
- Small adjustment to support negative batch_index
