### PR TITLE
Fix mask output

### DIFF
--- a/nodes.py
+++ b/nodes.py
@@ -562,7 +562,7 @@ class LoadImagesFromDirectory:
         if len(images) == 0:
             raise FileNotFoundError(f"No images could be loaded from directory '{directory}'.")
 
-        return (torch.cat(images, dim=0), torch.cat(masks, dim=0), image_count)
+        return (torch.cat(images, dim=0), torch.stack(masks, dim=0), image_count)
 
 
 


### PR DESCRIPTION
Masks were returned as single image, which wouldn't work with AnimateDiff. 
This was purely ChatGPT fix, seems to work:
Before:
![Screenshot 2023-09-24 182859](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/40791699/63c49d47-3937-4712-9ce7-f14390371101)
[](url)
After:
![Screenshot 2023-09-24 182832](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/40791699/ed4173df-40ae-4edf-91f6-326fdaba1c8a)