### PR TITLE
Fix for ControlLLLite control object on patches becoming None

### DIFF
--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -302,6 +302,7 @@ class ControlLLLiteAdvanced(ControlBase, AdvancedControlBase):
     def pre_run_advanced(self, *args, **kwargs):
         AdvancedControlBase.pre_run_advanced(self, *args, **kwargs)
         self.patch.set_control(self)
+        #logger.warn(f"in pre_run_advanced: {id(self)}")
     
     def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number: int):
         # normal ControlNet stuff

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -41,6 +41,7 @@ class LLLitePatch:
     def __init__(self, modules: dict[str, 'LLLiteModule'], control: Union[AdvancedControlBase, ControlBase]=None):
         self.modules = modules
         self.control = control
+        #logger.error(f"create LLLitePatch: {id(self)},{control}")
     
     def __call__(self, q, k, v, extra_options):
         # determine if have anything to run
@@ -72,21 +73,25 @@ class LLLitePatch:
         return q, k, v
 
     def to(self, device):
+        #logger.info(f"to... has control? {self.control}")
         for d in self.modules.keys():
             self.modules[d] = self.modules[d].to(device)
         return self
     
     def set_control(self, control: Union[AdvancedControlBase, ControlBase]):
         self.control = control
+        #logger.error(f"set control for LLLitePatch: {id(self)},{id(control)}")
 
     def clone_with_control(self, control: AdvancedControlBase):
+        #logger.error(f"clone-set control for LLLitePatch: {id(self)},{id(control)}")
         return LLLitePatch(self.modules, control)
 
     def cleanup(self):
-        del self.control
-        self.control = None
+        #del self.control
+        #self.control = None
         for module in self.modules.values():
             module.cleanup()
+        #logger.error(f"cleanup LLLitePatch: {id(self)}")
 
 
 # TODO: use comfy.ops to support fp8 properly


### PR DESCRIPTION
Hopefully, this doesn't introduce a memory leak - will keep an eye out.