### PR TITLE
Fixed ControlLLLite edge cases for certain latent sizes

### DIFF
--- a/adv_control/nodes_deprecated.py
+++ b/adv_control/nodes_deprecated.py
@@ -4,7 +4,7 @@ import torch
 
 import numpy as np
 from PIL import Image, ImageOps
-from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, TimestepKeyframe
+from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, TimestepKeyframe, BIGMAX
 from .logger import logger
 
 
@@ -16,8 +16,8 @@ class LoadImagesFromDirectory:
                 "directory": ("STRING", {"default": ""}),
             },
             "optional": {
-                "image_load_cap": ("INT", {"default": 0, "min": 0, "step": 1}),
-                "start_index": ("INT", {"default": 0, "min": 0, "step": 1}),
+                "image_load_cap": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
+                "start_index": ("INT", {"default": 0, "min": 0, "max": BIGMAX, "step": 1}),
             }
         }
     

--- a/adv_control/nodes_latent_keyframe.py
+++ b/adv_control/nodes_latent_keyframe.py
@@ -2,7 +2,7 @@ from typing import Union
 import numpy as np
 from collections.abc import Iterable
 
-from .utils import LatentKeyframe, LatentKeyframeGroup
+from .utils import LatentKeyframe, LatentKeyframeGroup, BIGMIN, BIGMAX
 from .utils import StrengthInterpolation as SI
 from .logger import logger
 
@@ -12,7 +12,7 @@ class LatentKeyframeNode:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "batch_index": ("INT", {"default": 0, "min": -1000, "max": 1000, "step": 1}),
+                "batch_index": ("INT", {"default": 0, "min": BIGMIN, "max": BIGMAX, "step": 1}),
                 "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
             },
             "optional": {
@@ -163,8 +163,8 @@ class LatentKeyframeInterpolationNode:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "batch_index_from": ("INT", {"default": 0, "min": -10000, "max": 10000, "step": 1}),
-                "batch_index_to_excl": ("INT", {"default": 0, "min": -10000, "max": 10000, "step": 1}),
+                "batch_index_from": ("INT", {"default": 0, "min": BIGMIN, "max": BIGMAX, "step": 1}),
+                "batch_index_to_excl": ("INT", {"default": 0, "min": BIGMIN, "max": BIGMAX, "step": 1}),
                 "strength_from": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "strength_to": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "interpolation": ([SI.LINEAR, SI.EASE_IN, SI.EASE_OUT, SI.EASE_IN_OUT], ),

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -11,6 +11,9 @@ from comfy.model_patcher import ModelPatcher
 
 from .logger import logger
 
+BIGMIN = -(2**63-1)
+BIGMAX = (2**63-1)
+
 def load_torch_file_with_dict_factory(controlnet_data: dict[str, Tensor], orig_load_torch_file: Callable):
     def load_torch_file_with_dict(*args, **kwargs):
         # immediately restore load_torch_file to original version
@@ -273,7 +276,7 @@ def deepcopy_with_sharing(obj, shared_attribute_names, memo=None):
         not calling from within __deepcopy__.
     '''
     assert isinstance(shared_attribute_names, (list, tuple))
-    
+
     shared_attributes = {k: getattr(obj, k) for k in shared_attribute_names}
 
     if hasattr(obj, '__deepcopy__'):

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Callable, Union
 import torch
 from torch import Tensor
@@ -257,6 +258,44 @@ def normalize_min_max(x: Tensor, new_min = 0.0, new_max = 1.0):
 
 def linear_conversion(x, x_min=0.0, x_max=1.0, new_min=0.0, new_max=1.0):
     return (((x - x_min)/(x_max - x_min)) * (new_max - new_min)) + new_min
+
+
+# from https://stackoverflow.com/a/24621200
+def deepcopy_with_sharing(obj, shared_attribute_names, memo=None):
+    '''
+    Deepcopy an object, except for a given list of attributes, which should
+    be shared between the original object and its copy.
+
+    obj is some object
+    shared_attribute_names: A list of strings identifying the attributes that
+        should be shared between the original and its copy.
+    memo is the dictionary passed into __deepcopy__.  Ignore this argument if
+        not calling from within __deepcopy__.
+    '''
+    assert isinstance(shared_attribute_names, (list, tuple))
+    
+    shared_attributes = {k: getattr(obj, k) for k in shared_attribute_names}
+
+    if hasattr(obj, '__deepcopy__'):
+        # Do hack to prevent infinite recursion in call to deepcopy
+        deepcopy_method = obj.__deepcopy__
+        obj.__deepcopy__ = None
+
+    for attr in shared_attribute_names:
+        del obj.__dict__[attr]
+
+    clone = deepcopy(obj)
+
+    for attr, val in shared_attributes.items():
+        setattr(obj, attr, val)
+        setattr(clone, attr, val)
+
+    if hasattr(obj, '__deepcopy__'):
+        # Undo hack
+        obj.__deepcopy__ = deepcopy_method
+        del clone.__deepcopy__
+
+    return clone
 
 
 class WeightTypeException(TypeError):


### PR DESCRIPTION
In addition to fixing ControlLLLite latent size edge cases:
 - Switched to using deepcopy overload in LLLitePatch instead of ControlLLLiteAdvanced object so that patches and control are always referring to the right objects.
- Refactored code to use BIGMIN and BIGMAX for INT inputs that shouldn't have limits.