### PR TITLE
Fix break caused by change to ComfyUI

### DIFF
--- a/adv_control/control_svd.py
+++ b/adv_control/control_svd.py
@@ -305,7 +305,7 @@ class SVDControlNet(nn.Module):
 
         cond = kwargs["cond"]
         num_video_frames = cond["num_video_frames"]
-        image_only_indicator = cond["image_only_indicator"]
+        image_only_indicator = cond.get("image_only_indicator", None)
         time_context = cond.get("time_context", None)
         del cond
 


### PR DESCRIPTION
ComfyUI changed such that `cond["image_only_indicator"]` throws a `KeyError` if not set. So we use the safer `get() `method to return a `None` in that case. We verified that None is treated correctly by downstream code in `get_alpha` in` utils.py`. 