### PR TITLE
Added reference_adain and reference_adain+attn support

### DIFF
--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -11,7 +11,7 @@ from .nodes_weight import (DefaultWeights, ScaledSoftMaskedUniversalWeights, Sca
     SoftT2IAdapterWeights, CustomT2IAdapterWeights)
 from .nodes_latent_keyframe import LatentKeyframeGroupNode, LatentKeyframeInterpolationNode, LatentKeyframeBatchedGroupNode, LatentKeyframeNode
 from .nodes_sparsectrl import SparseCtrlMergedLoaderAdvanced, SparseCtrlLoaderAdvanced, SparseIndexMethodNode, SparseSpreadMethodNode, RgbSparseCtrlPreprocessor
-from .nodes_reference import ReferenceControlNetNode, ReferencePreprocessorNode
+from .nodes_reference import ReferenceControlNetNode, ReferenceControlFinetune, ReferencePreprocessorNode
 from .nodes_loosecontrol import ControlNetLoaderWithLoraAdvanced
 from .nodes_deprecated import LoadImagesFromDirectory
 from .logger import logger
@@ -237,6 +237,7 @@ NODE_CLASS_MAPPINGS = {
     # Reference
     "ACN_ReferencePreprocessor": ReferencePreprocessorNode,
     "ACN_ReferenceControlNet": ReferenceControlNetNode,
+    "ACN_ReferenceControlNetFinetune": ReferenceControlFinetune,
     # LOOSEControl
     #"ACN_ControlNetLoaderWithLoraAdvanced": ControlNetLoaderWithLoraAdvanced,
     # Deprecated
@@ -266,12 +267,13 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     # SparseCtrl
     "ACN_SparseCtrlRGBPreprocessor": "RGB SparseCtrl 🛂🅐🅒🅝",
     "ACN_SparseCtrlLoaderAdvanced": "Load SparseCtrl Model 🛂🅐🅒🅝",
-    "ACN_SparseCtrlMergedLoaderAdvanced": "Load Merged SparseCtrl Model 🛂🅐🅒🅝",
+    "ACN_SparseCtrlMergedLoaderAdvanced": "🧪Load Merged SparseCtrl Model 🛂🅐🅒🅝",
     "ACN_SparseCtrlIndexMethodNode": "SparseCtrl Index Method 🛂🅐🅒🅝",
     "ACN_SparseCtrlSpreadMethodNode": "SparseCtrl Spread Method 🛂🅐🅒🅝",
     # Reference
     "ACN_ReferencePreprocessor": "Reference Preproccessor 🛂🅐🅒🅝",
     "ACN_ReferenceControlNet": "Reference ControlNet 🛂🅐🅒🅝",
+    "ACN_ReferenceControlNetFinetune": "Reference ControlNet (Finetune) 🛂🅐🅒🅝",
     # LOOSEControl
     #"ACN_ControlNetLoaderWithLoraAdvanced": "Load Adv. ControlNet Model w/ LoRA 🛂🅐🅒🅝",
     # Deprecated

--- a/adv_control/nodes_reference.py
+++ b/adv_control/nodes_reference.py
@@ -24,9 +24,38 @@ class ReferenceControlNetNode:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/Reference"
 
-    def load_controlnet(self, reference_type: str, style_fidelity: float, ref_weight: float, ref_with_other_cns: bool=False):
-        ref_opts = ReferenceOptions(reference_type=reference_type, style_fidelity=style_fidelity, ref_weight=ref_weight,
-                                    ref_with_other_cns=ref_with_other_cns)
+    def load_controlnet(self, reference_type: str, style_fidelity: float, ref_weight: float):
+        ref_opts = ReferenceOptions.create_combo(reference_type=reference_type, style_fidelity=style_fidelity, ref_weight=ref_weight)
+        controlnet = ReferenceAdvanced(ref_opts=ref_opts, timestep_keyframes=None)
+        return (controlnet,)
+
+
+class ReferenceControlFinetune:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "reference_type": (ReferenceType._LIST, {"default": ReferenceType.ATTN_ADAIN}),
+                "attn_style_fidelity": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "attn_ref_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "attn_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "adain_style_fidelity": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "adain_ref_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "adain_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+            },
+        }
+    
+    RETURN_TYPES = ("CONTROL_NET", )
+    FUNCTION = "load_controlnet"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/Reference"
+
+    def load_controlnet(self, reference_type: str,
+                        attn_style_fidelity: float, attn_ref_weight: float, attn_strength: float,
+                        adain_style_fidelity: float, adain_ref_weight: float, adain_strength: float):
+        ref_opts = ReferenceOptions(reference_type=reference_type,
+                                    attn_style_fidelity=attn_style_fidelity, attn_ref_weight=attn_ref_weight, attn_strength=attn_strength,
+                                    adain_style_fidelity=adain_style_fidelity, adain_ref_weight=adain_ref_weight, adain_strength=adain_strength)
         controlnet = ReferenceAdvanced(ref_opts=ref_opts, timestep_keyframes=None)
         return (controlnet,)
 

--- a/adv_control/nodes_reference.py
+++ b/adv_control/nodes_reference.py
@@ -35,7 +35,6 @@ class ReferenceControlFinetune:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "reference_type": (ReferenceType._LIST, {"default": ReferenceType.ATTN_ADAIN}),
                 "attn_style_fidelity": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "attn_ref_weight": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "attn_strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
@@ -50,10 +49,10 @@ class ReferenceControlFinetune:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/Reference"
 
-    def load_controlnet(self, reference_type: str,
+    def load_controlnet(self,
                         attn_style_fidelity: float, attn_ref_weight: float, attn_strength: float,
                         adain_style_fidelity: float, adain_ref_weight: float, adain_strength: float):
-        ref_opts = ReferenceOptions(reference_type=reference_type,
+        ref_opts = ReferenceOptions(reference_type=ReferenceType.ATTN_ADAIN,
                                     attn_style_fidelity=attn_style_fidelity, attn_ref_weight=attn_ref_weight, attn_strength=attn_strength,
                                     adain_style_fidelity=adain_style_fidelity, adain_ref_weight=adain_ref_weight, adain_strength=adain_strength)
         controlnet = ReferenceAdvanced(ref_opts=ref_opts, timestep_keyframes=None)

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -316,27 +316,6 @@ def broadcast_image_to_full(tensor, target_batch_size, batched_number, except_on
         return torch.cat([tensor] * batched_number, dim=0)
 
 
-def ddpm_noise_latents(latents: Tensor, sigma: Tensor, noise: Tensor=None):
-    sigma = sigma.unsqueeze(-1).unsqueeze(-1).unsqueeze(-1)
-    alpha_cumprod = 1 / ((sigma * sigma) + 1)
-    sqrt_alpha_prod = alpha_cumprod ** 0.5
-    sqrt_one_minus_alpha_prod = (1. - alpha_cumprod) ** 0.5
-    if noise is None:
-        # generator = torch.Generator(device="cuda")
-        # generator.manual_seed(0)
-        # generator = torch.Generator()
-        # generator.manual_seed(0)
-        # noise = torch.randn(latents.size(), generator=generator).to(latents.device)
-        noise = torch.randn_like(latents).to(latents.device)
-    return sqrt_alpha_prod * latents + sqrt_one_minus_alpha_prod * noise
-
-
-def simple_noise_latents(latents: Tensor, sigma: float, noise: Tensor=None):
-    if noise is None:
-        noise = torch.rand_like(latents)
-    return latents + noise * sigma
-
-
 # from https://stackoverflow.com/a/24621200
 def deepcopy_with_sharing(obj, shared_attribute_names, memo=None):
     '''


### PR DESCRIPTION
ReferenceCN now has both attn and adain support, like Auto1111, with the bonus of supporting proper strength support besides ref_weight.

Also added Reference ControlNet [Finetune] node to allow values to be selected individually for adain and attn.