### PR TITLE
ControlLora fix for weights error

### DIFF
--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -545,7 +545,6 @@ class AdvancedControlBase:
             self.prepare_weight_mask_cond_hint(x, self.batched_number)
             # adjust mask for current layer and return
             return torch.pow(self.weight_mask_cond_hint, self.get_calc_pow(idx=idx, layers=layers))
-        
         return self.weights.get(idx=idx)
     
     def get_calc_pow(self, idx: int, layers: int) -> int:

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -53,9 +53,12 @@ class ControlWeights:
             self.weights.reverse()
         self.weight_mask = weight_mask
 
-    def get(self, idx: int) -> Union[float, Tensor]:
+    def get(self, idx: int, default=1.0) -> Union[float, Tensor]:
         # if weights is not none, return index
         if self.weights is not None:
+            # this implies weights list is not aligning with expectations - will need to adjust code
+            if idx >= len(self.weights):
+                return default
             return self.weights[idx]
         return 1.0
 
@@ -542,6 +545,7 @@ class AdvancedControlBase:
             self.prepare_weight_mask_cond_hint(x, self.batched_number)
             # adjust mask for current layer and return
             return torch.pow(self.weight_mask_cond_hint, self.get_calc_pow(idx=idx, layers=layers))
+        
         return self.weights.get(idx=idx)
     
     def get_calc_pow(self, idx: int, layers: int) -> int:


### PR DESCRIPTION
SD1.5 ControlLora weights have a different amount of weights to them, so the previous code that assumed 10 layers would run into IndexError due to these ControlLora having 13. I will need to generalize code to properly match this amount of layers, but for now I added a quick fix to return weight 1.0 when index is out of bounds.