### PR TITLE
Updated Timestep Keyframes to use guarantee_steps + new Timestep Keyframe nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Loads a ControlNet model and converts it into an Advanced version that supports 
 - 🟪***CONTROL_NET***: loaded Advanced ControlNet
 
 ## Timestep Keyframe
-![image](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/7365912/c6f2a86e-fc96-4f8b-b976-7c2062a6eba2)
+![image](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/7365912/404f3cfe-5852-4eed-935b-37e32493d1b5)
 
 Scheduling node across timesteps (sampling steps) based on the set start_percent. Chaining Timestep Keyframes allows ControlNet scheduling across sampling steps (percentage-wise), through a timestep keyframe schedule.
 
@@ -92,7 +92,50 @@ Scheduling node across timesteps (sampling steps) based on the set start_percent
 - 🟦***strength***: strength of the controlnet; multiplies the controlnet by this value, basically, applied alongside the strength on the Apply ControlNet node. If set to 0.0 will not have any effect during the duration of this Timestep Keyframe's effect, and will increase sampling speed by not doing any work.
 - 🟦***null_latent_kf_strength***: strength to assign to latents that are unaccounted for in the passed in latent_keyframes. Has no effect if no latent_keyframes are passed in, or no batch_indeces are unaccounted in the latent_keyframes for during sampling.
 - 🟦***inherit_missing***: determines if should reuse values from previous Timestep Keyframes for optional values (control_net_weights, latent_keyframe, and mask_option) that are not included on this TimestepKeyframe. To inherit only specific inputs, use default inputs.
-- 🟦***guarantee_usage***: when true, even if a Timestep Keyframe's start_percent ahead of this one in the schedule is closer to current sampling percentage, this Timestep Keyframe will still be used for one step before moving on to the next selected Timestep Keyframe in the following step. Whether the Timestep Keyframe is used or not, its inputs will still be accounted for inherit_missing purposes.  
+- 🟦***guarantee_steps***: when 1 or greater, even if a Timestep Keyframe's start_percent ahead of this one in the schedule is closer to current sampling percentage, this Timestep Keyframe will still be used for the specified amount of steps before moving on to the next selected Timestep Keyframe in the following step. Whether the Timestep Keyframe is used or not, its inputs will still be accounted for inherit_missing purposes.  
+
+### Outputs
+- 🟪***TIMESTEP_KF***: the created Timestep Keyframe, that can either be linked to another or into a Timestep Keyframe input.
+
+## Timestep Keyframe Interpolation
+![image](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/7365912/9789617c-202c-4271-92a2-0909bcf9b108)
+
+Allows to create Timestep Keyframe with interpolated strength values in a given percent range. (The first generated keyframe will have guarantee_steps=1, rest that follow will have guarantee_steps=0).
+
+### Inputs
+- 🟨***prev_timestep_kf***: used to chain Timestep Keyframes together to create a schedule. The order does not matter - the Timestep Keyframes sort themselves automatically by their start_percent. *Any Timestep Keyframe contained in the prev_timestep_keyframe that contains the same start_percent as the Timestep Keyframe will be overwritten.*
+- 🟨***cn_weights***: weights to apply to controlnet while this Timestep Keyframe is in effect. Must be compatible with the loaded controlnet, or will throw an error explaining what weight types are compatible. If inherit_missing is True, if no control_net_weight is passed in, will attempt to reuse the last-used weights in the timestep keyframe schedule. *If Apply Advanced ControlNet node has a weight_override, the weight_override will be used during sampling instead of control_net_weight.*
+- 🟨***latent_keyframe***: latent keyframes to apply to controlnet while this Timestep Keyframe is in effect. If inherit_missing is True, if no latent_keyframe is passed in, will attempt to reuse the last-used weights in the timestep keyframe schedule. *If Apply Advanced ControlNet node has a latent_kf_override, the latent_lf_override will be used during sampling instead of latent_keyframe.*
+- 🟨***mask_optional***: attention masks to apply to controlnets; basically, decides what part of the image the controlnet to apply to (and the relative strength, if the mask is not binary). Same as mask_optional on the Apply Advanced ControlNet node, can apply either one maks to all latents, or individual masks for each latent. If inherit_missing is True, if no mask_optional is passed in, will attempt to reuse the last-used mask_optional in the timestep keyframe schedule. It is NOT overriden by mask_optional on the Apply  Advanced ControlNet node; will be used together.
+- 🟦***start_percent***: sampling step percentage at which the first generated Timestep Keyframe qualifies to be used.
+- 🟦***end_percent***: sampling step percentage at which the last generated Timestep Keyframe qualifies to be used.
+- 🟦***strength_start***: strength of the Timestep Keyframe at start of range.
+- 🟦***strength_end***: strength of the Timestep Keyframe at end of range.
+- 🟦***interpolation***: the method of interpolation.
+- 🟦***intervals***: the amount of keyframes to generate in total - the first will have its start_percent equal to start_percent, the last will have its start_percent equal to end_percent.
+- 🟦***null_latent_kf_strength***: strength to assign to latents that are unaccounted for in the passed in latent_keyframes. Has no effect if no latent_keyframes are passed in, or no batch_indeces are unaccounted in the latent_keyframes for during sampling.
+- 🟦***inherit_missing***: determines if should reuse values from previous Timestep Keyframes for optional values (control_net_weights, latent_keyframe, and mask_option) that are not included on this TimestepKeyframe. To inherit only specific inputs, use default inputs.
+- 🟦***print_keyframes***: if True, will print the Timestep Keyframes generated by this node for debugging purposes.
+
+### Outputs
+- 🟪***TIMESTEP_KF***: the created Timestep Keyframe, that can either be linked to another or into a Timestep Keyframe input.
+
+## Timestep Keyframe From List
+![image](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/7365912/9e9c23bf-6f82-4ce7-b4d1-3016fd14707d)
+
+Allows to create Timestep Keyframe via a list of floats, such as with Batch Value Schedule from [ComfyUI_FizzNodes](https://github.com/FizzleDorf/ComfyUI_FizzNodes) nodes. (The first generated keyframe will have guarantee_steps=1, rest that follow will have guarantee_steps=0).
+
+### Inputs
+- 🟨***prev_timestep_kf***: used to chain Timestep Keyframes together to create a schedule. The order does not matter - the Timestep Keyframes sort themselves automatically by their start_percent. *Any Timestep Keyframe contained in the prev_timestep_keyframe that contains the same start_percent as the Timestep Keyframe will be overwritten.*
+- 🟨***cn_weights***: weights to apply to controlnet while this Timestep Keyframe is in effect. Must be compatible with the loaded controlnet, or will throw an error explaining what weight types are compatible. If inherit_missing is True, if no control_net_weight is passed in, will attempt to reuse the last-used weights in the timestep keyframe schedule. *If Apply Advanced ControlNet node has a weight_override, the weight_override will be used during sampling instead of control_net_weight.*
+- 🟨***latent_keyframe***: latent keyframes to apply to controlnet while this Timestep Keyframe is in effect. If inherit_missing is True, if no latent_keyframe is passed in, will attempt to reuse the last-used weights in the timestep keyframe schedule. *If Apply Advanced ControlNet node has a latent_kf_override, the latent_lf_override will be used during sampling instead of latent_keyframe.*
+- 🟨***mask_optional***: attention masks to apply to controlnets; basically, decides what part of the image the controlnet to apply to (and the relative strength, if the mask is not binary). Same as mask_optional on the Apply Advanced ControlNet node, can apply either one maks to all latents, or individual masks for each latent. If inherit_missing is True, if no mask_optional is passed in, will attempt to reuse the last-used mask_optional in the timestep keyframe schedule. It is NOT overriden by mask_optional on the Apply  Advanced ControlNet node; will be used together.
+- 🟩***float_strengths***: a list of floats, that will correspond to the strength of each Timestep Keyframe; first will be assigned to start_percent, last will be assigned to end_percent, and the rest spread linearly between.
+- 🟦***start_percent***: sampling step percentage at which the first generated Timestep Keyframe qualifies to be used.
+- 🟦***end_percent***: sampling step percentage at which the last generated Timestep Keyframe qualifies to be used.
+- 🟦***null_latent_kf_strength***: strength to assign to latents that are unaccounted for in the passed in latent_keyframes. Has no effect if no latent_keyframes are passed in, or no batch_indeces are unaccounted in the latent_keyframes for during sampling.
+- 🟦***inherit_missing***: determines if should reuse values from previous Timestep Keyframes for optional values (control_net_weights, latent_keyframe, and mask_option) that are not included on this TimestepKeyframe. To inherit only specific inputs, use default inputs.
+- 🟦***print_keyframes***: if True, will print the Timestep Keyframes generated by this node for debugging purposes.
 
 ### Outputs
 - 🟪***TIMESTEP_KF***: the created Timestep Keyframe, that can either be linked to another or into a Timestep Keyframe input.
@@ -141,14 +184,14 @@ Allows to create Latent Keyframes with interpolated values in a range.
 ### Outputs
 - 🟪***LATENT_KF***: the created Latent Keyframe, that can either be linked to another or into a Latent Keyframe input.
 
-## Latent Keyframe Batched Group
+## Latent Keyframe From List
 ![image](https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet/assets/7365912/6cec701f-6183-4aeb-af5c-cac76f5591b7)
 
 Allows to create Latent Keyframes via a list of floats, such as with Batch Value Schedule from [ComfyUI_FizzNodes](https://github.com/FizzleDorf/ComfyUI_FizzNodes) nodes.
 
 ### Inputs
 - 🟨***prev_latent_kf***: used to chain Latent Keyframes together to create a schedule. *If any Latent Keyframes contained in prev_latent_keyframes have the same batch_index as a this Latent Keyframe, they will take priority over this node's version.* 
-- 🟦***float_strengths***: a list of floats, that will correspond to the strength of each Latent Keyframe; the batch_index is the index of each float value in the list.
+- 🟩***float_strengths***: a list of floats, that will correspond to the strength of each Latent Keyframe; the batch_index is the index of each float value in the list.
 - 🟦***print_keyframes***: if True, will print the Latent Keyframes generated by this node for debugging purposes.
 
 ### Outputs

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -244,4 +244,4 @@ class LLLiteModule(torch.nn.Module):
         cx = self.up(cx)
         if control.latent_keyframes is not None:
             cx = cx * control.calc_latent_keyframe_mults(x=cx, batched_number=control.batched_number)
-        return cx * mask * control.strength * control.current_timestep_keyframe.strength
+        return cx * mask * control.strength * control._current_timestep_keyframe.strength

--- a/adv_control/control_reference.py
+++ b/adv_control/control_reference.py
@@ -243,8 +243,8 @@ class ReferenceAdvanced(ControlBase, AdvancedControlBase):
 
     def get_effective_strength(self):
         effective_strength = self.strength
-        if self.current_timestep_keyframe is not None:
-            effective_strength = effective_strength * self.current_timestep_keyframe.strength
+        if self._current_timestep_keyframe is not None:
+            effective_strength = effective_strength * self._current_timestep_keyframe.strength
         return effective_strength
 
     def get_effective_attn_mask_or_float(self, x: Tensor, channels: int, is_mid: bool):
@@ -328,8 +328,8 @@ class ReferenceAdvanced(ControlBase, AdvancedControlBase):
         self.cond_hint = self.latent_format.process_in(self.cond_hint)
         self.cond_hint = ref_noise_latents(self.cond_hint, sigma=t, noise=None)
         timestep = self.model_sampling_current.timestep(t)
-        self.should_apply_attn_effective_strength = not (math.isclose(self.strength, 1.0) and math.isclose(self.current_timestep_keyframe.strength, 1.0) and math.isclose(self.ref_opts.attn_strength, 1.0))
-        self.should_apply_adain_effective_strength = not (math.isclose(self.strength, 1.0) and math.isclose(self.current_timestep_keyframe.strength, 1.0) and math.isclose(self.ref_opts.adain_strength, 1.0))
+        self.should_apply_attn_effective_strength = not (math.isclose(self.strength, 1.0) and math.isclose(self._current_timestep_keyframe.strength, 1.0) and math.isclose(self.ref_opts.attn_strength, 1.0))
+        self.should_apply_adain_effective_strength = not (math.isclose(self.strength, 1.0) and math.isclose(self._current_timestep_keyframe.strength, 1.0) and math.isclose(self.ref_opts.adain_strength, 1.0))
         # prepare mask - use direct_attn, so the mask dims will match source latents (and be smaller)
         self.prepare_mask_cond_hint(x_noisy=x_noisy, t=t, cond=cond, batched_number=batched_number, direct_attn=True)
         self.should_apply_effective_masks = self.latent_keyframes is not None or self.mask_cond_hint is not None or self.tk_mask_cond_hint is not None

--- a/adv_control/nodes_deprecated.py
+++ b/adv_control/nodes_deprecated.py
@@ -4,7 +4,7 @@ import torch
 
 import numpy as np
 from PIL import Image, ImageOps
-from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, TimestepKeyframe, BIGMAX
+from .utils import BIGMAX
 from .logger import logger
 
 
@@ -24,7 +24,7 @@ class LoadImagesFromDirectory:
     RETURN_TYPES = ("IMAGE", "MASK", "INT")
     FUNCTION = "load_images"
 
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/deprecated"
+    CATEGORY = ""
 
     def load_images(self, directory: str, image_load_cap: int = 0, start_index: int = 0):
         if not os.path.isdir(directory):
@@ -69,35 +69,3 @@ class LoadImagesFromDirectory:
             raise FileNotFoundError(f"No images could be loaded from directory '{directory}'.")
 
         return (torch.cat(images, dim=0), torch.stack(masks, dim=0), image_count)
-
-
-class TimestepKeyframeNodeDeprecated:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}, ),
-            },
-            "optional": {
-                "control_net_weights": ("CONTROL_NET_WEIGHTS", ),
-                "t2i_adapter_weights": ("T2I_ADAPTER_WEIGHTS", ),
-                "latent_keyframe": ("LATENT_KEYFRAME", ),
-                "prev_timestep_keyframe": ("TIMESTEP_KEYFRAME", ),
-            }
-        }
-    
-    RETURN_TYPES = ("TIMESTEP_KEYFRAME", )
-    FUNCTION = "load_keyframe"
-
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/keyframes"
-
-    def load_keyframe(self,
-                      start_percent: float,
-                      control_net_weights: ControlWeights=None,
-                      latent_keyframe: LatentKeyframeGroup=None,
-                      prev_timestep_keyframe: TimestepKeyframeGroup=None):
-        if not prev_timestep_keyframe:
-            prev_timestep_keyframe = TimestepKeyframeGroup()
-        keyframe = TimestepKeyframe(start_percent, control_net_weights, latent_keyframe)
-        prev_timestep_keyframe.add(keyframe)
-        return (prev_timestep_keyframe,)

--- a/adv_control/nodes_keyframes.py
+++ b/adv_control/nodes_keyframes.py
@@ -86,7 +86,7 @@ class TimestepKeyframeInterpolationNode:
     
     RETURN_NAMES = ("TIMESTEP_KF", )
     RETURN_TYPES = ("TIMESTEP_KEYFRAME", )
-    FUNCTION = "load_keyframes"
+    FUNCTION = "load_keyframe"
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/keyframes"
 
@@ -144,7 +144,7 @@ class TimestepKeyframeFromStrengthListNode:
     
     RETURN_NAMES = ("TIMESTEP_KF", )
     RETURN_TYPES = ("TIMESTEP_KEYFRAME", )
-    FUNCTION = "load_keyframes"
+    FUNCTION = "load_keyframe"
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/keyframes"
 

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -184,7 +184,7 @@ class TimestepKeyframe:
                  inherit_missing: bool = True,
                  guarantee_steps: int = 1,
                  mask_hint_orig: Tensor = None) -> None:
-        self.start_percent = start_percent
+        self.start_percent = float(start_percent)
         self.start_t = 999999999.9
         self.strength = strength
         self.control_weights = control_weights


### PR DESCRIPTION
- guarantee_usage changed to guarantee_steps to match my other scheduling nodes, allowing start_percents to be stacked and using guarantee_steps for per-step control
- added Timestep Keyframe Interpolation node
- added Timestep Keyframe From List node
- updated README