### PR TITLE
"ControlNet is more important" feature replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # ComfyUI-Advanced-ControlNet
 Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks. The ControlNet nodes here fully support sliding context sampling, like the one used in the  [ComfyUI-AnimateDiff-Evolved](https://github.com/Kosinkadink/ComfyUI-AnimateDiff-Evolved) nodes. Currently supports ControlNets, T2IAdapters, ControlLoRAs, ControlLLLite, SparseCtrls, SVD-ControlNets, and Reference.
 
-Custom weights allow replication of the "My prompt is more important" feature of Auto1111's sd-webui ControlNet extension.
+Custom weights allow replication of the "My prompt is more important" feature of Auto1111's sd-webui ControlNet extension via Soft Weights, and the "ControlNet is more important" feature can be granularly controlled by changing the uncond_multiplier on the same Soft Weights.
 
-ControlNet preprocessors are available through [comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux) nodes
+ControlNet preprocessors are available through [comfyui_controlnet_aux](https://github.com/Fannovel16/comfyui_controlnet_aux) nodes.
 
 ## Features
 - Timestep and latent strength scheduling
 - Attention masks
-- Soft weights to replicate "My prompt is more important" feature from sd-webui ControlNet extension, and also change the scaling
+- Replicate ***"My prompt is more important"*** feature from sd-webui-controlnet extension via ***Soft Weights***, and allow softness to be tweaked via ***base_multiplier***
+- Replicate ***"ControlNet is more important"*** feature from sd-webui-controlnet extension via ***uncond_multiplier*** on ***Soft Weights***
+  - uncond_multiplier=0.0 gives identical results of auto1111's feature, but values between 0.0 and 1.0 can be used without issue to granularly control the setting.
 - ControlNet, T2IAdapter, and ControlLoRA support for sliding context windows
 - ControlLLLite support (requires model_optional to be passed into and out of Apply Advanced ControlNet node)
 - SparseCtrl support

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -25,7 +25,7 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
 
     def get_universal_weights(self) -> ControlWeights:
         raw_weights = [(self.weights.base_multiplier ** float(12 - i)) for i in range(13)]
-        return ControlWeights.controlnet(raw_weights, self.weights.flip_weights)
+        return self.weights.copy_with_new_weights(raw_weights)
 
     def get_control_advanced(self, x_noisy, t, cond, batched_number):
         # perform special version of get_control that supports sliding context and masks
@@ -99,7 +99,7 @@ class T2IAdapterAdvanced(T2IAdapter, AdvancedControlBase):
         raw_weights = [(self.weights.base_multiplier ** float(7 - i)) for i in range(8)]
         raw_weights = [raw_weights[-8], raw_weights[-3], raw_weights[-2], raw_weights[-1]]
         raw_weights = get_properly_arranged_t2i_weights(raw_weights)
-        return ControlWeights.t2iadapter(raw_weights, self.weights.flip_weights)
+        return self.weights.copy_with_new_weights(raw_weights)
 
     def get_calc_pow(self, idx: int, layers: int) -> int:
         # match how T2IAdapterAdvanced deals with universal weights
@@ -152,7 +152,7 @@ class ControlLoraAdvanced(ControlLora, AdvancedControlBase):
     
     def get_universal_weights(self) -> ControlWeights:
         raw_weights = [(self.weights.base_multiplier ** float(9 - i)) for i in range(10)]
-        return ControlWeights.controllora(raw_weights, self.weights.flip_weights)
+        return self.weights.copy_with_new_weights(raw_weights)
 
     def copy(self):
         c = ControlLoraAdvanced(self.control_weights, self.timestep_keyframes, global_average_pooling=self.global_average_pooling)

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -244,4 +244,11 @@ class LLLiteModule(torch.nn.Module):
         cx = self.up(cx)
         if control.latent_keyframes is not None:
             cx = cx * control.calc_latent_keyframe_mults(x=cx, batched_number=control.batched_number)
+        if control.weights is not None and control.weights.has_uncond_multiplier:
+            cond_or_uncond = control.batched_number.cond_or_uncond
+            actual_length = cx.size(0) // control.batched_number
+            for idx, cond_type in enumerate(cond_or_uncond):
+                # if uncond, set to weight's uncond_multiplier
+                if cond_type == 1:
+                    cx[actual_length*idx:actual_length*(idx+1)] *= control.weights.uncond_multiplier
         return cx * mask * control.strength * control._current_timestep_keyframe.strength

--- a/adv_control/nodes_weight.py
+++ b/adv_control/nodes_weight.py
@@ -35,6 +35,9 @@ class ScaledSoftMaskedUniversalWeights:
                 #"lock_min": ("BOOLEAN", {"default": False}, ),
                 #"lock_max": ("BOOLEAN", {"default": False}, ),
             },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
+            }
         }
     
     RETURN_TYPES = ("CONTROL_NET_WEIGHTS", "TIMESTEP_KEYFRAME",)
@@ -43,7 +46,8 @@ class ScaledSoftMaskedUniversalWeights:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights"
 
-    def load_weights(self, mask: Tensor, min_base_multiplier: float, max_base_multiplier: float, lock_min=False, lock_max=False):
+    def load_weights(self, mask: Tensor, min_base_multiplier: float, max_base_multiplier: float, lock_min=False, lock_max=False,
+                     uncond_multiplier: float=1.0):
         # normalize mask
         mask = mask.clone()
         x_min = 0.0 if lock_min else mask.min()
@@ -52,7 +56,7 @@ class ScaledSoftMaskedUniversalWeights:
             mask = torch.ones_like(mask) * max_base_multiplier
         else:
             mask = linear_conversion(mask, x_min, x_max, min_base_multiplier, max_base_multiplier)
-        weights = ControlWeights.universal_mask(weight_mask=mask)
+        weights = ControlWeights.universal_mask(weight_mask=mask, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -64,6 +68,9 @@ class ScaledSoftUniversalWeights:
                 "base_multiplier": ("FLOAT", {"default": 0.825, "min": 0.0, "max": 1.0, "step": 0.001}, ),
                 "flip_weights": ("BOOLEAN", {"default": False}),
             },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
+            }
         }
     
     RETURN_TYPES = ("CONTROL_NET_WEIGHTS", "TIMESTEP_KEYFRAME",)
@@ -72,8 +79,8 @@ class ScaledSoftUniversalWeights:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights"
 
-    def load_weights(self, base_multiplier, flip_weights):
-        weights = ControlWeights.universal(base_multiplier=base_multiplier, flip_weights=flip_weights)
+    def load_weights(self, base_multiplier, flip_weights, uncond_multiplier: float=1.0):
+        weights = ControlWeights.universal(base_multiplier=base_multiplier, flip_weights=flip_weights, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights))) 
 
 
@@ -97,6 +104,9 @@ class SoftControlNetWeights:
                 "weight_12": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "flip_weights": ("BOOLEAN", {"default": False}),
             },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
+            }
         }
     
     RETURN_TYPES = ("CONTROL_NET_WEIGHTS", "TIMESTEP_KEYFRAME",)
@@ -106,10 +116,11 @@ class SoftControlNetWeights:
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights/ControlNet"
 
     def load_weights(self, weight_00, weight_01, weight_02, weight_03, weight_04, weight_05, weight_06, 
-                     weight_07, weight_08, weight_09, weight_10, weight_11, weight_12, flip_weights):
+                     weight_07, weight_08, weight_09, weight_10, weight_11, weight_12, flip_weights,
+                     uncond_multiplier: float=1.0):
         weights = [weight_00, weight_01, weight_02, weight_03, weight_04, weight_05, weight_06, 
                    weight_07, weight_08, weight_09, weight_10, weight_11, weight_12]
-        weights = ControlWeights.controlnet(weights, flip_weights=flip_weights)
+        weights = ControlWeights.controlnet(weights, flip_weights=flip_weights, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -132,6 +143,9 @@ class CustomControlNetWeights:
                 "weight_11": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "weight_12": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "flip_weights": ("BOOLEAN", {"default": False}),
+            },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
             }
         }
     
@@ -142,10 +156,11 @@ class CustomControlNetWeights:
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights/ControlNet"
 
     def load_weights(self, weight_00, weight_01, weight_02, weight_03, weight_04, weight_05, weight_06, 
-                     weight_07, weight_08, weight_09, weight_10, weight_11, weight_12, flip_weights):
+                     weight_07, weight_08, weight_09, weight_10, weight_11, weight_12, flip_weights,
+                     uncond_multiplier: float=1.0):
         weights = [weight_00, weight_01, weight_02, weight_03, weight_04, weight_05, weight_06, 
                    weight_07, weight_08, weight_09, weight_10, weight_11, weight_12]
-        weights = ControlWeights.controlnet(weights, flip_weights=flip_weights)
+        weights = ControlWeights.controlnet(weights, flip_weights=flip_weights, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -160,6 +175,9 @@ class SoftT2IAdapterWeights:
                 "weight_03": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "flip_weights": ("BOOLEAN", {"default": False}),
             },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
+            }
         }
     
     RETURN_TYPES = ("CONTROL_NET_WEIGHTS", "TIMESTEP_KEYFRAME",)
@@ -168,10 +186,11 @@ class SoftT2IAdapterWeights:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights/T2IAdapter"
 
-    def load_weights(self, weight_00, weight_01, weight_02, weight_03, flip_weights):
+    def load_weights(self, weight_00, weight_01, weight_02, weight_03, flip_weights,
+                     uncond_multiplier: float=1.0):
         weights = [weight_00, weight_01, weight_02, weight_03]
         weights = get_properly_arranged_t2i_weights(weights)
-        weights = ControlWeights.t2iadapter(weights, flip_weights=flip_weights)
+        weights = ControlWeights.t2iadapter(weights, flip_weights=flip_weights, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -186,6 +205,9 @@ class CustomT2IAdapterWeights:
                 "weight_03": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "flip_weights": ("BOOLEAN", {"default": False}),
             },
+            "optional": {
+                "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
+            }
         }
     
     RETURN_TYPES = ("CONTROL_NET_WEIGHTS", "TIMESTEP_KEYFRAME",)
@@ -194,8 +216,9 @@ class CustomT2IAdapterWeights:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights/T2IAdapter"
 
-    def load_weights(self, weight_00, weight_01, weight_02, weight_03, flip_weights):
+    def load_weights(self, weight_00, weight_01, weight_02, weight_03, flip_weights,
+                     uncond_multiplier: float=1.0):
         weights = [weight_00, weight_01, weight_02, weight_03]
         weights = get_properly_arranged_t2i_weights(weights)
-        weights = ControlWeights.t2iadapter(weights, flip_weights=flip_weights)
+        weights = ControlWeights.t2iadapter(weights, flip_weights=flip_weights, uncond_multiplier=uncond_multiplier)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -519,7 +519,7 @@ class AdvancedControlBase:
         self.context_length = 0
         # timesteps
         self.t: Tensor = None
-        self.batched_number: int = None
+        self.batched_number: Union[int, IntWithCondOrUncond] = None
         self.batch_size: int = 0
         # weights + override
         self.weights: ControlWeights = None

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -520,6 +520,7 @@ class AdvancedControlBase:
         # timesteps
         self.t: Tensor = None
         self.batched_number: int = None
+        self.batch_size: int = 0
         # weights + override
         self.weights: ControlWeights = None
         self.weights_default: ControlWeights = weights_default
@@ -573,6 +574,7 @@ class AdvancedControlBase:
     def prepare_current_timestep(self, t: Tensor, batched_number: int):
         self.t = float(t[0])
         self.batched_number = batched_number
+        self.batch_size = len(t)
         # get current step percent
         curr_t: float = self.t
         prev_index = self._current_timestep_index
@@ -667,8 +669,6 @@ class AdvancedControlBase:
         return True
 
     def get_control_inject(self, x_noisy, t, cond, batched_number):
-        if type(batched_number) != IntWithCondOrUncond:
-            logger.warn(f"not IntWithCondOrUncond! {type(batched_number)}")
         # prepare timestep and everything related
         self.prepare_current_timestep(t=t, batched_number=batched_number)
         # if should not perform any actions for the controlnet, exit without doing any work
@@ -869,6 +869,7 @@ class AdvancedControlBase:
         self.context_length = 0
         self.t = None
         self.batched_number = None
+        self.batch_size = 0
         self.weights = None
         self.latent_keyframes = None
         # timestep stuff


### PR DESCRIPTION
Also called "guess_mode" in diffusers. Implemented via the uncond_multiplier on Soft Weights. When set to 0.0, replicates auto1111 exactly, but any value between 0.0 and 1.0 also works without issue, allowing for granular control.

In terms of how it works under the hood, "ControlNet is more important" makes the control input/output not modify the uncond, so in auto1111 it simply multiplies the uncond controlnet components by 0.0. No reason why you couldn't make this granular, so I exposed it as uncond_multiplier instead of a boolean.

In ComfyUI, the controlnet components do not get direct access to know where the conds and unconds are located in the passed-in latents, so for now I take advantage of the fact that the built-in len function is used when calling get_control in calc_conds_batch, and prior to that, comfy.samplers.cond_cat is called ONLY in calc_conds_batch. Assuming all other custom calc_conds_batch implementations also keep this order of execution (and they should have to), I make cond_cat wrap the len function so that when the object that len is being taken care of matches the characteristics of the cond_or_uncond list (contains 1's and 0's), it will instead return a IntWithCondOrUncond object containing the (alleged) cond_or_uncond value, then it will clean itself up and restore itself to the original len function. This prevents things from going awry if other threads use the len function between the cond_cat wrapping and the len function unwrapping. Using this hacked int object, get_control can then access cond_or_uncond for further use. An additional wrapper around the default sampling functions (for ksampler/custom ksampler) to not use the wrapped cond_cat function if no controlnet weights have a non-default uncond_multiplier. From testing, there is only the small fraction of a percent speed difference between doing cond_cat being wrapped all the time vs not, but I will do this just in case.

The advantage of this hacky approach vs making separate ControlNets for cond vs uncond is that this will work with Timestep Keyframes w/ different weights out of the box.

As soon as ComfyUI makes controlnet stuff have access to cond_or_uncond, I will refactor this code to no longer require these wraps