### PR TITLE
Make attn RefCN compatible with recent ComfyUI (backwards compatible)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-advanced-controlnet"
 description = "Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks."
-version = "1.0.1"
+version = "1.0.2"
 license = "LICENSE"
 dependencies = []
 


### PR DESCRIPTION
As of commit https://github.com/comfyanonymous/ComfyUI/commit/0bdc2b15c75426af75a326d5966ad47aab5b76d3 , BasicTransformerBlock no longer has a ```_forward``` function, only ```forward```. This causes attn RefCN to break.

This PR make it work while maintaining backwards compatibility.