### PR TITLE
Add automatic workaround for outdated Steerable-Motion workflow issue

### DIFF
--- a/adv_control/nodes_sparsectrl.py
+++ b/adv_control/nodes_sparsectrl.py
@@ -6,7 +6,7 @@ import comfy.utils
 from comfy.sd import VAE
 
 from .utils import TimestepKeyframeGroup
-from .control_sparsectrl import SparseMethod, SparseIndexMethod, SparseSettings, SparseSpreadMethod, PreprocSparseRGBWrapper, SparseConst, SparseContextAware
+from .control_sparsectrl import SparseMethod, SparseIndexMethod, SparseSettings, SparseSpreadMethod, PreprocSparseRGBWrapper, SparseConst, SparseContextAware, get_idx_list_from_str
 from .control import load_sparsectrl, load_controlnet, ControlNetAdvanced, SparseCtrlAdvanced
 
 
@@ -103,21 +103,7 @@ class SparseIndexMethodNode:
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/SparseCtrl"
 
     def get_method(self, indexes: str):
-        idxs = []
-        unique_idxs = set()
-        # get indeces from string
-        str_idxs = [x.strip() for x in indexes.strip().split(",")]
-        for str_idx in str_idxs:
-            try:
-                idx = int(str_idx)
-                if idx in unique_idxs:
-                    raise ValueError(f"'{idx}' is duplicated; indexes must be unique.")
-                idxs.append(idx)
-                unique_idxs.add(idx)
-            except ValueError:
-                raise ValueError(f"'{str_idx}' is not a valid integer index.")
-        if len(idxs) == 0:
-            raise ValueError(f"No indexes were listed in Sparse Index Method.")
+        idxs = get_idx_list_from_str(indexes)
         return (SparseIndexMethod(idxs),)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-advanced-controlnet"
 description = "Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks."
-version = "1.0.4"
+version = "1.0.5"
 license = "LICENSE"
 dependencies = []
 


### PR DESCRIPTION
If incorrect string input connection due to old Steerable-Motion workflows is detected, will attempt to convert to indexes (and warning will point finger at Steerable-Motion over any errors that occur to keep me from seeing reports about this, since it isn't the fault of my code at all).