### PR TITLE
Rework ModelPatcher for upcoming ComfyUI update

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,9 @@
 from .adv_control.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 from .adv_control import documentation
+from .adv_control.dinklink import init_dinklink
 
 WEB_DIRECTORY = "./web"
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS', "WEB_DIRECTORY"]
 documentation.format_descriptions(NODE_CLASS_MAPPINGS)
+
+init_dinklink()

--- a/__init__.py
+++ b/__init__.py
@@ -1,9 +1,11 @@
 from .adv_control.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
 from .adv_control import documentation
 from .adv_control.dinklink import init_dinklink
+from .adv_control.sampling import prepare_dinklink_acn_wrapper
 
 WEB_DIRECTORY = "./web"
 __all__ = ['NODE_CLASS_MAPPINGS', 'NODE_DISPLAY_NAME_MAPPINGS', "WEB_DIRECTORY"]
 documentation.format_descriptions(NODE_CLASS_MAPPINGS)
 
 init_dinklink()
+prepare_dinklink_acn_wrapper()

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -504,6 +504,8 @@ def load_controlnet(ckpt_path, timestep_keyframe: TimestepKeyframeGroup=None, mo
             control = comfy_cn.load_controlnet(ckpt_path, model=model)
         finally:
             comfy.utils.load_torch_file = orig_load_torch_file
+    if control is None:
+        raise Exception(f"Something went wrong when loading '{ckpt_path}'; ControlNet is None.")
     return convert_to_advanced(control, timestep_keyframe=timestep_keyframe)
 
 

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -481,6 +481,8 @@ class SparseCtrlAdvanced(ControlNetAdvanced):
             self.model_latent_format = None
         self.local_sparse_idxs = None
         self.local_sparse_idxs_inverse = None
+        if self.motion_model is not None:
+            self.motion_model.cleanup()
 
     def copy(self):
         c = SparseCtrlAdvanced(self.control_model, self.motion_model, self.timestep_keyframes, self.sparse_settings, self.global_average_pooling, self.load_device, self.manual_cast_dtype)

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -129,7 +129,7 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
                                   global_average_pooling=v.global_average_pooling, compression_ratio=v.compression_ratio, latent_format=v.latent_format, load_device=v.load_device,
                                   manual_cast_dtype=v.manual_cast_dtype)
         v.copy_to(to_return)
-        to_return.control_model_wrapped = v.control_model_wrapped.clone()
+        to_return.control_model_wrapped = v.control_model_wrapped.clone() # needed to avoid breaking memory management system (parent tracking)
         return to_return
 
 

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -66,7 +66,7 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
                 del self.cond_hint
             self.cond_hint = None
             compression_ratio = self.compression_ratio
-            if self.vae is not None:
+            if self.vae is not None and self.mult_by_ratio_when_vae:
                 compression_ratio *= self.vae.downscale_ratio
             # if self.cond_hint_original length greater or equal to real latent count, subdivide it before scaling
             if self.sub_idxs is not None:
@@ -483,6 +483,10 @@ def load_controlnet(ckpt_path, timestep_keyframe: TimestepKeyframeGroup=None, mo
         # ControlNet++ check
         elif "task_embedding" in key:
             pass
+        # CtrLoRA check
+        elif "lora_layer" in key:
+            controlnet_type = ControlWeightType.CTRLORA
+            break
 
     if has_controlnet_key and has_motion_modules_key:
         controlnet_type = ControlWeightType.SPARSECTRL
@@ -496,6 +500,8 @@ def load_controlnet(ckpt_path, timestep_keyframe: TimestepKeyframeGroup=None, mo
             control = load_sparsectrl(ckpt_path, controlnet_data=controlnet_data, timestep_keyframe=timestep_keyframe, model=model)
         elif controlnet_type == ControlWeightType.SVD_CONTROLNET:
             control = load_svdcontrolnet(ckpt_path, controlnet_data=controlnet_data, timestep_keyframe=timestep_keyframe)
+        elif controlnet_type == ControlWeightType.CTRLORA:
+            raise Exception("This is a CtrLoRA; use the Load CtrLoRA Model node.")
     # otherwise, load vanilla ControlNet
     else:
         try:

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -14,7 +14,7 @@ from comfy.model_patcher import ModelPatcher
 from .control_sparsectrl import SparseControlNet, SparseCtrlMotionWrapper, SparseSettings, SparseConst, create_sparse_modelpatcher
 from .control_lllite import LLLiteModule, LLLitePatch, load_controllllite
 from .control_svd import svd_unet_config_from_diffusers_unet, SVDControlNet, svd_unet_to_diffusers
-from .utils import (AdvancedControlBase, TimestepKeyframeGroup, LatentKeyframeGroup, AbstractPreprocWrapper, ControlWeightType, ControlWeights, WeightTypeException,
+from .utils import (AdvancedControlBase, TimestepKeyframeGroup, LatentKeyframeGroup, AbstractPreprocWrapper, ControlWeightType, ControlWeights, WeightTypeException, Extras,
                     manual_cast_clean_groupnorm, disable_weight_init_clean_groupnorm, prepare_mask_batch, get_properly_arranged_t2i_weights, load_torch_file_with_dict_factory,
                     broadcast_image_to_extend, extend_to_batch_size, ORIG_PREVIOUS_CONTROLNET, CONTROL_INIT_BY_ACN)
 from .logger import logger
@@ -30,7 +30,7 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
     def get_universal_weights(self) -> ControlWeights:
         def cn_weights_func(idx: int, control: dict[str, list[Tensor]], key: str):
             if key == "middle":
-                return 1.0
+                return 1.0 * self.weights.extras.get(Extras.MIDDLE_MULT, 1.0)
             c_len = len(control[key])
             raw_weights = [(self.weights.base_multiplier ** float((c_len) - i)) for i in range(c_len+1)]
             raw_weights = raw_weights[:-1]
@@ -155,7 +155,7 @@ class T2IAdapterAdvanced(T2IAdapter, AdvancedControlBase):
     def get_universal_weights(self) -> ControlWeights:
         def t2i_weights_func(idx: int, control: dict[str, list[Tensor]], key: str):
             if key == "middle":
-                return 1.0
+                return 1.0 * self.weights.extras.get(Extras.MIDDLE_MULT, 1.0)
             c_len = 8 #len(control[key])
             raw_weights = [(self.weights.base_multiplier ** float((c_len-1) - i)) for i in range(c_len)]
             raw_weights = [raw_weights[-c_len], raw_weights[-3], raw_weights[-2], raw_weights[-1]]

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -316,6 +316,7 @@ class SparseCtrlAdvanced(ControlNetAdvanced):
         self.control_model_wrapped = create_sparse_modelpatcher(self.control_model, load_device=load_device, offload_device=comfy.model_management.unet_offload_device())
         self.add_compatible_weight(ControlWeightType.SPARSECTRL)
         self.control_model: SparseControlNet = self.control_model  # does nothing except help with IDE hints
+        self.postpone_condhint_latents_check = True
         if self.control_model.use_simplified_conditioning_embedding:
             # TODO: allow vae_optional to be used instead of preprocessor
             #self.require_vae = True

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -129,6 +129,7 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
                                   global_average_pooling=v.global_average_pooling, compression_ratio=v.compression_ratio, latent_format=v.latent_format, load_device=v.load_device,
                                   manual_cast_dtype=v.manual_cast_dtype)
         v.copy_to(to_return)
+        to_return.control_model_wrapped = v.control_model_wrapped.clone()
         return to_return
 
 

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -11,7 +11,7 @@ import comfy.controlnet as comfy_cn
 from comfy.controlnet import ControlBase, ControlNet, ControlLora, T2IAdapter, StrengthType
 from comfy.model_patcher import ModelPatcher
 
-from .control_sparsectrl import SparseModelPatcher, SparseControlNet, SparseCtrlMotionWrapper, SparseSettings, SparseConst
+from .control_sparsectrl import SparseControlNet, SparseCtrlMotionWrapper, SparseSettings, SparseConst, create_sparse_modelpatcher
 from .control_lllite import LLLiteModule, LLLitePatch, load_controllllite
 from .control_svd import svd_unet_config_from_diffusers_unet, SVDControlNet, svd_unet_to_diffusers
 from .utils import (AdvancedControlBase, TimestepKeyframeGroup, LatentKeyframeGroup, AbstractPreprocWrapper, ControlWeightType, ControlWeights, WeightTypeException,
@@ -313,7 +313,7 @@ class SVDControlNetAdvanced(ControlNetAdvanced):
 class SparseCtrlAdvanced(ControlNetAdvanced):
     def __init__(self, control_model, timestep_keyframes: TimestepKeyframeGroup, sparse_settings: SparseSettings=None, global_average_pooling=False, load_device=None, manual_cast_dtype=None):
         super().__init__(control_model=control_model, timestep_keyframes=timestep_keyframes, global_average_pooling=global_average_pooling, load_device=load_device, manual_cast_dtype=manual_cast_dtype)
-        self.control_model_wrapped = SparseModelPatcher(self.control_model, load_device=load_device, offload_device=comfy.model_management.unet_offload_device())
+        self.control_model_wrapped = create_sparse_modelpatcher(self.control_model, load_device=load_device, offload_device=comfy.model_management.unet_offload_device())
         self.add_compatible_weight(ControlWeightType.SPARSECTRL)
         self.control_model: SparseControlNet = self.control_model  # does nothing except help with IDE hints
         if self.control_model.use_simplified_conditioning_embedding:

--- a/adv_control/control_ctrlora.py
+++ b/adv_control/control_ctrlora.py
@@ -1,0 +1,228 @@
+import torch
+from torch import Tensor
+
+from comfy.cldm.cldm import ControlNet as ControlNetCLDM
+import comfy.model_detection
+import comfy.model_management
+import comfy.ops
+import comfy.utils
+
+from comfy.ldm.modules.diffusionmodules.util import (
+    zero_module,
+    timestep_embedding,
+)
+
+from .control import ControlNetAdvanced
+from .utils import TimestepKeyframeGroup
+from .logger import logger
+
+
+class ControlNetCtrLoRA(ControlNetCLDM):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # delete input hint block
+        del self.input_hint_block
+    
+    def forward(self, x: Tensor, hint: Tensor, timesteps, context, y=None, **kwargs):
+        t_emb = timestep_embedding(timesteps, self.model_channels, repeat_only=False).to(x.dtype)
+        emb = self.time_embed(t_emb)
+
+        out_output = []
+        out_middle = []
+
+        if self.num_classes is not None:
+            assert y.shape[0] == x.shape[0]
+            emb = emb + self.label_emb(y)
+        
+        h = hint.to(dtype=x.dtype)
+        for module, zero_conv in zip(self.input_blocks, self.zero_convs):
+            h = module(h, emb, context)
+            out_output.append(zero_conv(h, emb, context))
+        
+        h = self.middle_block(h, emb, context)
+        out_middle.append(self.middle_block_out(h, emb, context))
+
+        return {"middle": out_middle, "output": out_output}
+
+
+class CtrLoRAAdvanced(ControlNetAdvanced):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.require_vae = True
+        self.mult_by_ratio_when_vae = False
+
+    def pre_run_advanced(self, model, percent_to_timestep_function):
+        super().pre_run_advanced(model, percent_to_timestep_function)
+        self.latent_format = model.latent_format  # LatentFormat object, used to process_in latent cond hint
+
+    def cleanup_advanced(self):
+        super().cleanup_advanced()
+        if self.latent_format is not None:
+            del self.latent_format
+            self.latent_format = None
+
+    def copy(self):
+        c = CtrLoRAAdvanced(self.control_model, self.timestep_keyframes, global_average_pooling=self.global_average_pooling, load_device=self.load_device, manual_cast_dtype=self.manual_cast_dtype)
+        c.control_model = self.control_model
+        c.control_model_wrapped = self.control_model_wrapped
+        self.copy_to(c)
+        self.copy_to_advanced(c)
+        return c
+
+
+def load_ctrlora(base_path: str, lora_path: str,
+                 base_data: dict[str, Tensor]=None, lora_data: dict[str, Tensor]=None,
+                 timestep_keyframe: TimestepKeyframeGroup=None, model=None, model_options={}):
+    if base_data is None:
+        base_data = comfy.utils.load_torch_file(base_path, safe_load=True)
+    controlnet_data = base_data
+
+    # first, check that base_data contains keys with lora_layer
+    contains_lora_layers = False
+    for key in base_data:
+        if "lora_layer" in key:
+            contains_lora_layers = True
+    if not contains_lora_layers:
+        raise Exception(f"File '{base_path}' is not a valid CtrLoRA base model; does not contain any lora_layer keys.")
+    
+    controlnet_config = None
+    supported_inference_dtypes = None
+
+    pth_key = 'control_model.zero_convs.0.0.weight'
+    pth = False
+    key = 'zero_convs.0.0.weight'
+    if pth_key in controlnet_data:
+        pth = True
+        key = pth_key
+        prefix = "control_model."
+    elif key in controlnet_data:
+        prefix = ""
+    else:
+        raise Exception("")
+        net = load_t2i_adapter(controlnet_data, model_options=model_options)
+        if net is None:
+            logging.error("error could not detect control model type.")
+        return net
+
+    if controlnet_config is None:
+        model_config = comfy.model_detection.model_config_from_unet(controlnet_data, prefix, True)
+        supported_inference_dtypes = list(model_config.supported_inference_dtypes)
+        controlnet_config = model_config.unet_config
+
+    unet_dtype = model_options.get("dtype", None)
+    if unet_dtype is None:
+        weight_dtype = comfy.utils.weight_dtype(controlnet_data)
+
+        if supported_inference_dtypes is None:
+            supported_inference_dtypes = [comfy.model_management.unet_dtype()]
+
+        if weight_dtype is not None:
+            supported_inference_dtypes.append(weight_dtype)
+
+        unet_dtype = comfy.model_management.unet_dtype(model_params=-1, supported_dtypes=supported_inference_dtypes)
+
+    load_device = comfy.model_management.get_torch_device()
+
+    manual_cast_dtype = comfy.model_management.unet_manual_cast(unet_dtype, load_device)
+    operations = model_options.get("custom_operations", None)
+    if operations is None:
+        operations = comfy.ops.pick_operations(unet_dtype, manual_cast_dtype)
+
+    controlnet_config["operations"] = operations
+    controlnet_config["dtype"] = unet_dtype
+    controlnet_config["device"] = comfy.model_management.unet_offload_device()
+    controlnet_config.pop("out_channels")
+    controlnet_config["hint_channels"] = 3
+    #controlnet_config["hint_channels"] = controlnet_data["{}input_hint_block.0.weight".format(prefix)].shape[1]
+    control_model = ControlNetCtrLoRA(**controlnet_config)
+
+    if pth:
+        if 'difference' in controlnet_data:
+            if model is not None:
+                comfy.model_management.load_models_gpu([model])
+                model_sd = model.model_state_dict()
+                for x in controlnet_data:
+                    c_m = "control_model."
+                    if x.startswith(c_m):
+                        sd_key = "diffusion_model.{}".format(x[len(c_m):])
+                        if sd_key in model_sd:
+                            cd = controlnet_data[x]
+                            cd += model_sd[sd_key].type(cd.dtype).to(cd.device)
+            else:
+                logger.warning("WARNING: Loaded a diff controlnet without a model. It will very likely not work.")
+
+        class WeightsLoader(torch.nn.Module):
+            pass
+        w = WeightsLoader()
+        w.control_model = control_model
+        missing, unexpected = w.load_state_dict(controlnet_data, strict=False)
+    else:
+        missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
+
+    if len(missing) > 0:
+        logger.warning("missing controlnet keys: {}".format(missing))
+
+    if len(unexpected) > 0:
+        logger.debug("unexpected controlnet keys: {}".format(unexpected))
+
+    global_average_pooling = model_options.get("global_average_pooling", False)
+    control = CtrLoRAAdvanced(control_model, timestep_keyframe, global_average_pooling=global_average_pooling,
+                                 load_device=load_device, manual_cast_dtype=manual_cast_dtype)
+    # load lora data onto the controlnet
+    if lora_path is not None:
+        load_lora_data(control, lora_path)
+
+    return control
+
+
+def load_lora_data(control: CtrLoRAAdvanced, lora_path: str, loaded_data: dict[str, Tensor]=None, lora_strength=1.0):
+    if loaded_data is None:
+        loaded_data = comfy.utils.load_torch_file(lora_path, safe_load=True)
+    # check that lora_data contains keys with lora_layer
+    contains_lora_layers = False
+    for key in loaded_data:
+        if "lora_layer" in key:
+            contains_lora_layers = True
+    if not contains_lora_layers:
+        raise Exception(f"File '{lora_path}' is not a valid CtrLoRA lora model; does not contain any lora_layer keys.")
+
+    # now that we know we have a ctrlora file, separate keys into 'set' and 'lora' keys
+    data_set: dict[str, Tensor] = {}
+    data_lora: dict[str, Tensor] = {}
+
+    for key in list(loaded_data.keys()):
+        if 'lora_layer' in key:
+            data_lora[key] = loaded_data.pop(key)
+        else:
+            data_set[key] = loaded_data.pop(key)
+    # no keys should be left over
+    if len(loaded_data) > 0:
+        logger.warning("Not all keys from CtrlLoRA lora model's loaded data were parsed!")
+    
+    # turn set/lora data into corresponding patches;
+    patches = {}
+    # set will replace the values
+    for key, value in data_set.items():
+        # prase model key from key;
+        # remove "control_model."
+        model_key = key.replace("control_model.", "")
+        patches[model_key] = ("set", (value,))
+    # lora will do mm of up and down tensors
+    for down_key in data_lora:
+        # only process lora down keys; we will process both up+down at the same time
+        if ".up." in key:
+            continue
+        # get up version of down key
+        up_key = down_key.replace(".down.", ".up.")
+        # get key that will match up with model key;
+        # remove "lora_layer.down." and "control_model."
+        model_key = down_key.replace("lora_layer.down.", "").replace("control_model.", "")
+        
+        weight_down = data_lora[down_key]
+        weight_up = data_lora[up_key]
+        # currently, ComfyUI expects 6 elements in 'lora' type, but for future-proofing add a bunch more with None
+        patches[model_key] = ("lora", (weight_up, weight_down, None, None, None, None,
+                                       None, None, None, None, None, None, None, None))
+    
+    # now that patches are made, add them to model
+    control.control_model_wrapped.add_patches(patches, strength_patch=lora_strength)

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -319,11 +319,11 @@ class ControlLLLiteAdvanced(ControlBase, AdvancedControlBase):
         self.patch_attn2.set_control(self)
         #logger.warn(f"in pre_run_advanced: {id(self)}")
     
-    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number: int):
+    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number: int, transformer_options):
         # normal ControlNet stuff
         control_prev = None
         if self.previous_controlnet is not None:
-            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number)
+            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number, transformer_options)
 
         if self.timestep_range is not None:
             if t[0] > self.timestep_range[0] or t[0] < self.timestep_range[1]:

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -15,7 +15,7 @@ from comfy.controlnet import ControlBase
 
 from .logger import logger
 from .utils import (AdvancedControlBase, TimestepKeyframeGroup, ControlWeights, broadcast_image_to_extend, extend_to_batch_size,
-                    deepcopy_with_sharing, prepare_mask_batch)
+                    prepare_mask_batch)
 
 
 # based on set_model_patch code in comfy/model_patcher.py
@@ -115,26 +115,8 @@ class LLLitePatch:
         return LLLitePatch(self.modules, self.patch_type, control)
 
     def cleanup(self):
-        #total_cleaned = 0
         for module in self.modules.values():
             module.cleanup()
-        #    total_cleaned += 1
-        #logger.info(f"cleaned modules: {total_cleaned}, {id(self)}")
-        #logger.error(f"cleanup LLLitePatch: {id(self)}")
-
-    # make sure deepcopy does not copy control, and deepcopied LLLitePatch should be assigned to control
-    # def __deepcopy__(self, memo):
-    #     self.cleanup()
-    #     to_return: LLLitePatch = deepcopy_with_sharing(self, shared_attribute_names = ['control'], memo=memo)
-    #     #logger.warn(f"patch {id(self)} turned into {id(to_return)}")
-    #     try:
-    #         if self.patch_type == self.ATTN1:
-    #             to_return.control.patch_attn1 = to_return
-    #         elif self.patch_type == self.ATTN2:
-    #             to_return.control.patch_attn2 = to_return
-    #     except Exception:
-    #         pass
-    #     return to_return
 
 
 # TODO: use comfy.ops to support fp8 properly
@@ -387,17 +369,6 @@ class ControlLLLiteAdvanced(ControlBase, AdvancedControlBase):
         self.copy_to(c)
         self.copy_to_advanced(c)
         return c
-    
-    # deepcopy needs to properly keep track of objects to work between model.clone calls!
-    # def __deepcopy__(self, *args, **kwargs):
-    #     self.cleanup_advanced()
-    #     return self
-
-    # def get_models(self):
-    #     # get_models is called once at the start of every KSampler run - use to reset already_patched status
-    #     out = super().get_models()
-    #     logger.error(f"in get_models! {id(self)}")
-    #     return out
 
 
 def load_controllllite(ckpt_path: str, controlnet_data: dict[str, Tensor]=None, timestep_keyframe: TimestepKeyframeGroup=None):

--- a/adv_control/control_lllite.py
+++ b/adv_control/control_lllite.py
@@ -302,10 +302,6 @@ class ControlLLLiteAdvanced(ControlBase, AdvancedControlBase):
         set_model_attn1_patch(model_options, self.patch_attn1.set_control(self))
         set_model_attn2_patch(model_options, self.patch_attn2.set_control(self))
 
-    # def patch_model(self, model: ModelPatcher):
-    #     model.set_model_attn1_patch(self.patch_attn1)
-    #     model.set_model_attn2_patch(self.patch_attn2)
-
     def set_cond_hint_inject(self, *args, **kwargs):
         to_return = super().set_cond_hint_inject(*args, **kwargs)
         # cond hint for LLLite needs to be scaled between (-1, 1) instead of (0, 1)

--- a/adv_control/control_plusplus.py
+++ b/adv_control/control_plusplus.py
@@ -22,7 +22,7 @@ import comfy.model_management
 import comfy.model_detection
 import comfy.utils
 
-from .utils import (AdvancedControlBase, ControlWeights, ControlWeightType, TimestepKeyframeGroup, AbstractPreprocWrapper,
+from .utils import (AdvancedControlBase, ControlWeights, ControlWeightType, TimestepKeyframeGroup, AbstractPreprocWrapper, Extras,
                     extend_to_batch_size, broadcast_image_to_extend)
 from .logger import logger
 
@@ -239,7 +239,7 @@ class ControlNetPlusPlusAdvanced(ControlNet, AdvancedControlBase):
     def get_universal_weights(self) -> ControlWeights:
         def cn_weights_func(idx: int, control: dict[str, list[Tensor]], key: str):
             if key == "middle":
-                return 1.0
+                return 1.0 * self.weights.extras.get(Extras.MIDDLE_MULT, 1.0)
             c_len = len(control[key])
             raw_weights = [(self.weights.base_multiplier ** float((c_len) - i)) for i in range(c_len+1)]
             raw_weights = raw_weights[:-1]

--- a/adv_control/control_plusplus.py
+++ b/adv_control/control_plusplus.py
@@ -276,10 +276,10 @@ class ControlNetPlusPlusAdvanced(ControlNet, AdvancedControlBase):
             self.cond_hint_original = pp_group
         return to_return
 
-    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number):
+    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number, transformer_options):
         control_prev = None
         if self.previous_controlnet is not None:
-            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number)
+            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number, transformer_options)
 
         if self.timestep_range is not None:
             if t[0] > self.timestep_range[0] or t[0] < self.timestep_range[1]:

--- a/adv_control/control_reference.py
+++ b/adv_control/control_reference.py
@@ -452,7 +452,10 @@ class BankStylesBasicTransformerBlock:
                 per_i[i].append(bank)
         real_banks = []
         for bank in per_i:
-            combined = torch.cat(bank, dim=0)
+            if len(bank) == 1:
+                combined = bank[0]
+            else:
+                combined = torch.cat(bank, dim=0)
             real_banks.append(combined)
         return real_banks
 
@@ -917,7 +920,7 @@ def _forward_inject_BasicTransformerBlock(self: RefBasicTransformerBlock, x: Ten
             value_attn1 = n
         n = self.attn1.to_q(n)
         # Reference CN READ - use attn1_replace_patch appropriately
-        if len(ref_read_cns) > 0 and len(self.injection_holder.bank_styles.get_bank(uuids, ignore_contextref_read)) > 0:
+        if len(ref_read_cns) > 0 and len(self.injection_holder.bank_styles.get_cn_idxs(uuids, ignore_contextref_read)) > 0:
             bank_styles = self.injection_holder.bank_styles
             style_fidelity = bank_styles.get_avg_style_fidelity(uuids, ignore_contextref_read)
             real_bank = bank_styles.get_bank(uuids, ignore_contextref_read, cdevice=n.device).copy()
@@ -954,7 +957,7 @@ def _forward_inject_BasicTransformerBlock(self: RefBasicTransformerBlock, x: Ten
             n = self.attn1.to_out(n)
     else:
         # Reference CN READ - no attn1_replace_patch
-        if len(ref_read_cns) > 0 and len(self.injection_holder.bank_styles.get_bank(uuids, ignore_contextref_read)) > 0:
+        if len(ref_read_cns) > 0 and len(self.injection_holder.bank_styles.get_cn_idxs(uuids, ignore_contextref_read)) > 0:
             if context_attn1 is None:
                 context_attn1 = n
             bank_styles = self.injection_holder.bank_styles

--- a/adv_control/control_reference.py
+++ b/adv_control/control_reference.py
@@ -316,7 +316,7 @@ class ReferenceAdvanced(ControlBase, AdvancedControlBase):
         return self
 
 
-def handle_context_ref_setup(contextref_obj, transformer_options: dict, conds: list[dict]):
+def handle_context_ref_setup(contextref_obj, transformer_options: dict, conds: dict[str, list[dict, str]]):
     transformer_options[CONTEXTREF_MACHINE_STATE] = MachineState.OFF
     # verify version is compatible
     if contextref_obj.version > HIGHEST_VERSION_SUPPORT:
@@ -371,7 +371,7 @@ def _create_tks_from_dict_list(dlist: list[dict[str]]) -> TimestepKeyframeGroup:
     return tks
 
 
-def _add_context_ref_to_conds(conds: list[list[dict[str]]], context_ref: ReferenceAdvanced):
+def _add_context_ref_to_conds(conds: dict[list[dict[str]]], context_ref: ReferenceAdvanced):
     def _add_context_ref_to_existing_control(control: ControlBase, context_ref: ReferenceAdvanced):
         curr_cn = control
         while curr_cn is not None:
@@ -395,10 +395,10 @@ def _add_context_ref_to_conds(conds: list[list[dict[str]]], context_ref: Referen
         actual_cond[CONTROL_INIT_BY_ACN] = True
     
     # either add context_ref to end of existing cnet chain, or init 'control' key on actual cond
-    for cond in conds:
+    for cond_type in conds:
+        cond = conds[cond_type]
         if cond is not None:
-            for sub_cond in cond:
-                actual_cond = sub_cond[1]
+            for actual_cond in cond:
                 _add_context_ref(actual_cond, context_ref)
 
 

--- a/adv_control/control_reference.py
+++ b/adv_control/control_reference.py
@@ -239,11 +239,11 @@ class ReferenceAdvanced(ControlBase, AdvancedControlBase):
                 ropts.attn_style_fidelity = ropts.original_attn_style_fidelity
                 ropts.adain_style_fidelity = ropts.original_adain_style_fidelity
 
-    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number: int):
+    def get_control_advanced(self, x_noisy: Tensor, t, cond, batched_number: int, transformer_options):
         # normal ControlNet stuff
         control_prev = None
         if self.previous_controlnet is not None:
-            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number)
+            control_prev = self.previous_controlnet.get_control(x_noisy, t, cond, batched_number, transformer_options)
 
         if self.timestep_range is not None:
             if t[0] > self.timestep_range[0] or t[0] < self.timestep_range[1]:

--- a/adv_control/control_sparsectrl.py
+++ b/adv_control/control_sparsectrl.py
@@ -396,6 +396,7 @@ def get_position_encoding_max_len(mm_state_dict: dict[str, Tensor], mm_name: str
     raise ValueError(f"No pos_encoder.pe found in SparseCtrl state_dict - {mm_name} is not a valid SparseCtrl model!")
 
 
+# TODO: replace with DinkLink reference from ADE
 class SparseCtrlMotionWrapper(nn.Module):
     def __init__(self, mm_state_dict: dict[str, Tensor], ops=disable_weight_init_clean_groupnorm):
         super().__init__()

--- a/adv_control/control_sparsectrl.py
+++ b/adv_control/control_sparsectrl.py
@@ -30,6 +30,7 @@ import comfy.ops
 import comfy.model_management
 import comfy.utils
 
+from .dinklink import get_AnimateDiffModel, get_AnimateDiffInfo
 from .logger import logger
 from .utils import (BIGMAX, AbstractPreprocWrapper, disable_weight_init_clean_groupnorm,
                     prepare_mask_batch, broadcast_image_to_extend, extend_to_batch_size)

--- a/adv_control/control_sparsectrl.py
+++ b/adv_control/control_sparsectrl.py
@@ -3,58 +3,30 @@
 #and then taken from comfy/cldm/cldm.py and modified again
 
 from abc import ABC, abstractmethod
-import copy
-import math
 import numpy as np
-from typing import Iterable, Union
 import torch
-import torch as th
-import torch.nn as nn
 from torch import Tensor
-from einops import rearrange, repeat
 
 from comfy.ldm.modules.diffusionmodules.util import (
     zero_module,
     timestep_embedding,
 )
 
-from comfy.cli_args import args
 from comfy.cldm.cldm import ControlNet as ControlNetCLDM
-from comfy.ldm.modules.attention import SpatialTransformer
-from comfy.ldm.modules.attention import attention_basic, attention_pytorch, attention_split, attention_sub_quad, default
-from comfy.ldm.modules.attention import FeedForward, SpatialTransformer
 from comfy.ldm.modules.diffusionmodules.openaimodel import TimestepEmbedSequential
 from comfy.model_patcher import ModelPatcher
-from comfy.patcher_extension import CallbacksMP
-import comfy.ops
-import comfy.model_management
-import comfy.utils
+from comfy.patcher_extension import PatcherInjection
 
-from .dinklink import get_AnimateDiffModel, get_AnimateDiffInfo
+from .dinklink import (InterfaceAnimateDiffInfo, InterfaceAnimateDiffModel,
+                       get_CreateMotionModelPatcher, get_AnimateDiffModel, get_AnimateDiffInfo)
 from .logger import logger
-from .utils import (BIGMAX, AbstractPreprocWrapper, disable_weight_init_clean_groupnorm,
-                    prepare_mask_batch, broadcast_image_to_extend, extend_to_batch_size)
+from .utils import (BIGMAX, AbstractPreprocWrapper, disable_weight_init_clean_groupnorm, WrapperConsts)
 
 
-# until xformers bug is fixed, do not use xformers for VersatileAttention! TODO: change this when fix is out
-# logic for choosing optimized_attention method taken from comfy/ldm/modules/attention.py
-# a fallback_attention_mm is selected to avoid CUDA configuration limitation with pytorch's scaled_dot_product
-optimized_attention_mm = attention_basic
-fallback_attention_mm = attention_basic
-if comfy.model_management.xformers_enabled():
-    pass
-    #optimized_attention_mm = attention_xformers
-if comfy.model_management.pytorch_attention_enabled():
-    optimized_attention_mm = attention_pytorch
-    if args.use_split_cross_attention:
-        fallback_attention_mm = attention_split
-    else:
-        fallback_attention_mm = attention_sub_quad
-else:
-    if args.use_split_cross_attention:
-        optimized_attention_mm = attention_split
-    else:
-        optimized_attention_mm = attention_sub_quad
+class SparseMotionModelPatcher(ModelPatcher):
+    '''Class only used for IDE type hints.'''
+    def __init__(self, *args, **kwargs):
+        self.model = InterfaceAnimateDiffModel
 
 
 class SparseConst:
@@ -74,11 +46,6 @@ class SparseControlNet(ControlNetCLDM):
             self.input_hint_block = TimestepEmbedSequential(
                 zero_module(operations.conv_nd(self.dims, hint_channels, self.model_channels, 3, padding=1, dtype=self.dtype, device=device)),
             )
-        self.motion_wrapper: SparseCtrlMotionWrapper = None
-    
-    def set_actual_length(self, actual_length: int, full_length: int):
-        if self.motion_wrapper is not None:
-            self.motion_wrapper.set_video_length(video_length=actual_length, full_length=full_length)
 
     def forward(self, x: Tensor, hint: Tensor, timesteps, context, y=None, **kwargs):
         t_emb = timestep_embedding(timesteps, self.model_channels, repeat_only=False).to(x.dtype)
@@ -112,47 +79,44 @@ class SparseControlNet(ControlNetCLDM):
         return {"middle": out_middle, "output": out_output}
 
 
-def create_sparse_modelpatcher(model, load_device, offload_device):
+def load_sparsectrl_motionmodel(ckpt_path: str, motion_data: dict[str, Tensor], ops=None) -> InterfaceAnimateDiffModel:
+    mm_info: InterfaceAnimateDiffInfo = get_AnimateDiffInfo()("SD1.5", "AnimateDiff", "v3", ckpt_path)
+    init_kwargs = {
+        "ops": ops,
+        "get_unet_func": _get_unet_func,
+    }
+    motion_model: InterfaceAnimateDiffModel = get_AnimateDiffModel()(mm_state_dict=motion_data, mm_info=mm_info, init_kwargs=init_kwargs)
+    missing, unexpected = motion_model.load_state_dict(motion_data)
+    if len(missing) > 0 or len(unexpected) > 0:
+        logger.info(f"SparseCtrl MotionModel: {missing}, {unexpected}")
+    return motion_model
+
+
+def create_sparse_modelpatcher(model, motion_model, load_device, offload_device):
     patcher = ModelPatcher(model, load_device=load_device, offload_device=offload_device)
-    acn = "ACN"
-    patcher.add_callback_with_key(CallbacksMP.ON_LOAD, acn, _patch_lowvram_extras)
-    patcher.add_callback_with_key(CallbacksMP.ON_LOAD, acn, _handle_float8_pe_tensors)
+    if motion_model is not None:
+        _motionpatcher = _create_sparse_motionmodelpatcher(motion_model, load_device, offload_device)
+        patcher.set_additional_models(WrapperConsts.ACN, [_motionpatcher])
+        patcher.set_injections(WrapperConsts.ACN,
+                            [PatcherInjection(inject=_inject_motion_models, eject=_eject_motion_models)])
     return patcher
 
-
-def _patch_lowvram_extras(self: ModelPatcher, device_to, lowvram_model_memory, force_patch_weights, full_load, *args, **kwargs):
-    if lowvram_model_memory > 0:
-        motion_wrapper: SparseCtrlMotionWrapper = self.model.motion_wrapper
-        if motion_wrapper is not None:
-            # figure out the tensors (likely pe's) that should be cast to device besides just the named_modules
-            remaining_tensors = list(motion_wrapper.state_dict().keys())
-            named_modules = []
-            for n, _ in motion_wrapper.named_modules():
-                named_modules.append(n)
-                named_modules.append(f"{n}.weight")
-                named_modules.append(f"{n}.bias")
-            for name in named_modules:
-                if name in remaining_tensors:
-                    remaining_tensors.remove(name)
-
-            for key in remaining_tensors:
-                self.patch_weight_to_device(key, device_to)
-                if device_to is not None:
-                    comfy.utils.set_attr(motion_wrapper, key, comfy.utils.get_attr(motion_wrapper, key).to(device_to))
+def _create_sparse_motionmodelpatcher(motion_model, load_device, offload_device) -> SparseMotionModelPatcher:
+    return get_CreateMotionModelPatcher()(motion_model, load_device, offload_device)
 
 
-def _handle_float8_pe_tensors(self: ModelPatcher, *args, **kwargs):
-    motion_wrapper: SparseCtrlMotionWrapper = self.model.motion_wrapper
-    if motion_wrapper is not None:
-        remaining_tensors = list(motion_wrapper.state_dict().keys())
-        pe_tensors = [x for x in remaining_tensors if '.pe' in x]
-        is_first = True
-        for key in pe_tensors:
-            if is_first:
-                is_first = False
-                if comfy.utils.get_attr(motion_wrapper, key).dtype not in [torch.float8_e5m2, torch.float8_e4m3fn]:
-                    break
-            comfy.utils.set_attr(motion_wrapper, key, comfy.utils.get_attr(motion_wrapper, key).half())
+def _inject_motion_models(patcher: ModelPatcher):
+    motion_models: list[SparseMotionModelPatcher] = patcher.get_additional_models_with_key(WrapperConsts.ACN)
+    for mm in motion_models:
+        mm.model.inject(patcher)
+
+def _eject_motion_models(patcher: ModelPatcher):
+    motion_models: list[SparseMotionModelPatcher] = patcher.get_additional_models_with_key(WrapperConsts.ACN)
+    for mm in motion_models:
+        mm.model.eject(patcher)
+
+def _get_unet_func(wrapper, model: ModelPatcher):
+    return model.model
 
 
 class PreprocSparseRGBWrapper(AbstractPreprocWrapper):
@@ -353,705 +317,3 @@ def get_idx_list_from_str(indexes: str) -> list[int]:
     if len(idxs) == 0:
         raise ValueError(f"No indexes were listed in Sparse Index Method.")
     return idxs
-
-
-#########################################
-# motion-related portion of controlnet
-class BlockType:
-    UP = "up"
-    DOWN = "down"
-    MID = "mid"
-
-def get_down_block_max(mm_state_dict: dict[str, Tensor]) -> int:
-    return get_block_max(mm_state_dict, "down_blocks")
-
-def get_up_block_max(mm_state_dict: dict[str, Tensor]) -> int:
-    return get_block_max(mm_state_dict, "up_blocks")
-
-def get_block_max(mm_state_dict: dict[str, Tensor], block_name: str) -> int:
-    # keep track of biggest down_block count in module
-    biggest_block = -1
-    for key in mm_state_dict.keys():
-        if block_name in key:
-            try:
-                block_int = key.split(".")[1]
-                block_num = int(block_int)
-                if block_num > biggest_block:
-                    biggest_block = block_num
-            except ValueError:
-                pass
-    return biggest_block
-
-def has_mid_block(mm_state_dict: dict[str, Tensor]):
-    # check if keys contain mid_block
-    for key in mm_state_dict.keys():
-        if key.startswith("mid_block."):
-            return True
-    return False
-
-def get_position_encoding_max_len(mm_state_dict: dict[str, Tensor], mm_name: str=None) -> int:
-    # use pos_encoder.pe entries to determine max length - [1, {max_length}, {320|640|1280}]
-    for key in mm_state_dict.keys():
-        if key.endswith("pos_encoder.pe"):
-            return mm_state_dict[key].size(1) # get middle dim
-    raise ValueError(f"No pos_encoder.pe found in SparseCtrl state_dict - {mm_name} is not a valid SparseCtrl model!")
-
-
-# TODO: replace with DinkLink reference from ADE
-class SparseCtrlMotionWrapper(nn.Module):
-    def __init__(self, mm_state_dict: dict[str, Tensor], ops=disable_weight_init_clean_groupnorm):
-        super().__init__()
-        self.down_blocks: Iterable[MotionModule] = None
-        self.up_blocks: Iterable[MotionModule] = None
-        self.mid_block: MotionModule = None
-        self.encoding_max_len = get_position_encoding_max_len(mm_state_dict, "")
-        layer_channels = (320, 640, 1280, 1280)
-        if get_down_block_max(mm_state_dict) > -1:
-            self.down_blocks = nn.ModuleList([])
-            for c in layer_channels:
-                self.down_blocks.append(MotionModule(c, temporal_position_encoding_max_len=self.encoding_max_len, block_type=BlockType.DOWN, ops=ops))
-        if get_up_block_max(mm_state_dict) > -1:
-            self.up_blocks = nn.ModuleList([])
-            for c in reversed(layer_channels):
-                self.up_blocks.append(MotionModule(c, temporal_position_encoding_max_len=self.encoding_max_len, block_type=BlockType.UP, ops=ops))
-        if has_mid_block(mm_state_dict):
-            self.mid_block = MotionModule(1280, temporal_position_encoding_max_len=self.encoding_max_len, block_type=BlockType.MID, ops=ops)
-
-    def inject(self, unet: SparseControlNet):
-        # inject input (down) blocks
-        self._inject(unet.input_blocks, self.down_blocks)
-        # inject mid block, if present
-        if self.mid_block is not None:
-            self._inject([unet.middle_block], [self.mid_block])
-        unet.motion_wrapper = self
-
-    def _inject(self, unet_blocks: nn.ModuleList, mm_blocks: nn.ModuleList):
-        # Rules for injection:
-        # For each component list in a unet block:
-        #     if SpatialTransformer exists in list, place next block after last occurrence
-        #     elif ResBlock exists in list, place next block after first occurrence
-        #     else don't place block
-        injection_count = 0
-        unet_idx = 0
-        # details about blocks passed in
-        per_block = len(mm_blocks[0].motion_modules)
-        injection_goal = len(mm_blocks) * per_block
-        # only stop injecting when modules exhausted
-        while injection_count < injection_goal:
-            # figure out which VanillaTemporalModule from mm to inject
-            mm_blk_idx, mm_vtm_idx = injection_count // per_block, injection_count % per_block
-            # figure out layout of unet block components
-            st_idx = -1 # SpatialTransformer index
-            res_idx = -1 # first ResBlock index
-            # first, figure out indeces of relevant blocks
-            for idx, component in enumerate(unet_blocks[unet_idx]):
-                if type(component) == SpatialTransformer:
-                    st_idx = idx
-                elif type(component).__name__ == "ResBlock" and res_idx < 0:
-                    res_idx = idx
-            # if SpatialTransformer exists, inject right after
-            if st_idx >= 0:
-                unet_blocks[unet_idx].insert(st_idx+1, mm_blocks[mm_blk_idx].motion_modules[mm_vtm_idx])
-                injection_count += 1
-            # otherwise, if only ResBlock exists, inject right after
-            elif res_idx >= 0:
-                unet_blocks[unet_idx].insert(res_idx+1, mm_blocks[mm_blk_idx].motion_modules[mm_vtm_idx])
-                injection_count += 1
-            # increment unet_idx
-            unet_idx += 1
-
-    def eject(self, unet: SparseControlNet):
-        # remove from input blocks (downblocks)
-        self._eject(unet.input_blocks)
-        # remove from middle block (encapsulate in list to make compatible)
-        self._eject([unet.middle_block])
-        del unet.motion_wrapper
-        unet.motion_wrapper = None
-
-    def _eject(self, unet_blocks: nn.ModuleList):
-        # eject all VanillaTemporalModule objects from all blocks
-        for block in unet_blocks:
-            idx_to_pop = []
-            for idx, component in enumerate(block):
-                if type(component) == VanillaTemporalModule:
-                    idx_to_pop.append(idx)
-            # pop in backwards order, as to not disturb what the indeces refer to
-            for idx in sorted(idx_to_pop, reverse=True):
-                block.pop(idx)
-
-    def set_video_length(self, video_length: int, full_length: int):
-        self.AD_video_length = video_length
-        if self.down_blocks is not None:
-            for block in self.down_blocks:
-                block.set_video_length(video_length, full_length)
-        if self.up_blocks is not None:
-            for block in self.up_blocks:
-                block.set_video_length(video_length, full_length)
-        if self.mid_block is not None:
-            self.mid_block.set_video_length(video_length, full_length)
-    
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        if self.down_blocks is not None:
-            for block in self.down_blocks:
-                block.set_scale_multiplier(multiplier)
-        if self.up_blocks is not None:
-            for block in self.up_blocks:
-                block.set_scale_multiplier(multiplier)
-        if self.mid_block is not None:
-            self.mid_block.set_scale_multiplier(multiplier)
-
-    def set_strength(self, strength: float):
-        if self.down_blocks is not None:
-            for block in self.down_blocks:
-                block.set_strength(strength)
-        if self.up_blocks is not None:
-            for block in self.up_blocks:
-                block.set_strength(strength)
-        if self.mid_block is not None:
-            self.mid_block.set_strength(strength)
-
-    def reset_temp_vars(self):
-        if self.down_blocks is not None:
-            for block in self.down_blocks:
-                block.reset_temp_vars()
-        if self.up_blocks is not None:
-            for block in self.up_blocks:
-                block.reset_temp_vars()
-        if self.mid_block is not None:
-            self.mid_block.reset_temp_vars()
-
-    def reset_scale_multiplier(self):
-        self.set_scale_multiplier(None)
-
-    def reset(self):
-        self.reset_scale_multiplier()
-        self.reset_temp_vars()
-
-
-class MotionModule(nn.Module):
-    def __init__(self, in_channels, temporal_position_encoding_max_len=24, block_type: str=BlockType.DOWN, ops=disable_weight_init_clean_groupnorm):
-        super().__init__()
-        if block_type == BlockType.MID:
-            # mid blocks contain only a single VanillaTemporalModule
-            self.motion_modules: Iterable[VanillaTemporalModule] = nn.ModuleList([get_motion_module(in_channels, temporal_position_encoding_max_len, ops=ops)])
-        else:
-            # down blocks contain two VanillaTemporalModules
-            self.motion_modules: Iterable[VanillaTemporalModule] = nn.ModuleList(
-                [
-                    get_motion_module(in_channels, temporal_position_encoding_max_len, ops=ops),
-                    get_motion_module(in_channels, temporal_position_encoding_max_len, ops=ops)
-                ]
-            )
-            # up blocks contain one additional VanillaTemporalModule
-            if block_type == BlockType.UP:
-                self.motion_modules.append(get_motion_module(in_channels, temporal_position_encoding_max_len, ops=ops))
-    
-    def set_video_length(self, video_length: int, full_length: int):
-        for motion_module in self.motion_modules:
-            motion_module.set_video_length(video_length, full_length)
-    
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        for motion_module in self.motion_modules:
-            motion_module.set_scale_multiplier(multiplier)
-    
-    def set_masks(self, masks: Tensor, min_val: float, max_val: float):
-        for motion_module in self.motion_modules:
-            motion_module.set_masks(masks, min_val, max_val)
-    
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        for motion_module in self.motion_modules:
-            motion_module.set_sub_idxs(sub_idxs)
-
-    def set_strength(self, strength: float):
-        for motion_module in self.motion_modules:
-            motion_module.set_strength(strength)
-
-    def reset_temp_vars(self):
-        for motion_module in self.motion_modules:
-            motion_module.reset_temp_vars()
-
-
-def get_motion_module(in_channels, temporal_position_encoding_max_len, ops=disable_weight_init_clean_groupnorm):
-    # unlike normal AD, there is only one attention block expected in SparseCtrl models
-    return VanillaTemporalModule(in_channels=in_channels, attention_block_types=("Temporal_Self",), temporal_position_encoding_max_len=temporal_position_encoding_max_len, ops=ops)
-
-
-class VanillaTemporalModule(nn.Module):
-    def __init__(
-        self,
-        in_channels,
-        num_attention_heads=8,
-        num_transformer_block=1,
-        attention_block_types=("Temporal_Self", "Temporal_Self"),
-        cross_frame_attention_mode=None,
-        temporal_position_encoding=True,
-        temporal_position_encoding_max_len=24,
-        temporal_attention_dim_div=1,
-        zero_initialize=True,
-        ops=disable_weight_init_clean_groupnorm,
-    ):
-        super().__init__()
-        self.strength = 1.0
-        self.temporal_transformer = TemporalTransformer3DModel(
-            in_channels=in_channels,
-            num_attention_heads=num_attention_heads,
-            attention_head_dim=in_channels
-            // num_attention_heads
-            // temporal_attention_dim_div,
-            num_layers=num_transformer_block,
-            attention_block_types=attention_block_types,
-            cross_frame_attention_mode=cross_frame_attention_mode,
-            temporal_position_encoding=temporal_position_encoding,
-            temporal_position_encoding_max_len=temporal_position_encoding_max_len,
-            ops=ops,
-        )
-
-        if zero_initialize:
-            self.temporal_transformer.proj_out = zero_module(
-                self.temporal_transformer.proj_out
-            )
-
-    def set_video_length(self, video_length: int, full_length: int):
-        self.temporal_transformer.set_video_length(video_length, full_length)
-    
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        self.temporal_transformer.set_scale_multiplier(multiplier)
-
-    def set_masks(self, masks: Tensor, min_val: float, max_val: float):
-        self.temporal_transformer.set_masks(masks, min_val, max_val)
-    
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        self.temporal_transformer.set_sub_idxs(sub_idxs)
-
-    def set_strength(self, strength: float):
-        self.strength = strength
-
-    def reset_temp_vars(self):
-        self.set_strength(1.0)
-        self.temporal_transformer.reset_temp_vars()
-
-    def forward(self, input_tensor, encoder_hidden_states=None, attention_mask=None):
-        if math.isclose(self.strength, 1.0):
-            return self.temporal_transformer(input_tensor, encoder_hidden_states, attention_mask)
-        elif math.isclose(self.strength, 0.0):
-            return input_tensor
-        # elif self.strength > 1.0:
-        #     return self.temporal_transformer(input_tensor, encoder_hidden_states, attention_mask)*self.strength
-        else:
-            return self.temporal_transformer(input_tensor, encoder_hidden_states, attention_mask)*self.strength + input_tensor*(1.0-self.strength)
-
-
-class TemporalTransformer3DModel(nn.Module):
-    def __init__(
-        self,
-        in_channels,
-        num_attention_heads,
-        attention_head_dim,
-        num_layers,
-        attention_block_types=(
-            "Temporal_Self",
-            "Temporal_Self",
-        ),
-        dropout=0.0,
-        norm_num_groups=32,
-        cross_attention_dim=768,
-        activation_fn="geglu",
-        attention_bias=False,
-        upcast_attention=False,
-        cross_frame_attention_mode=None,
-        temporal_position_encoding=False,
-        temporal_position_encoding_max_len=24,
-        ops=disable_weight_init_clean_groupnorm,
-    ):
-        super().__init__()
-        self.video_length = 16
-        self.full_length = 16
-        self.scale_min = 1.0
-        self.scale_max = 1.0
-        self.raw_scale_mask: Union[Tensor, None] = None
-        self.temp_scale_mask: Union[Tensor, None] = None
-        self.sub_idxs: Union[list[int], None] = None
-        self.prev_hidden_states_batch = 0
-
-
-        inner_dim = num_attention_heads * attention_head_dim
-
-        self.norm = ops.GroupNorm(
-            num_groups=norm_num_groups, num_channels=in_channels, eps=1e-6, affine=True
-        )
-        self.proj_in = ops.Linear(in_channels, inner_dim)
-
-        self.transformer_blocks: Iterable[TemporalTransformerBlock] = nn.ModuleList(
-            [
-                TemporalTransformerBlock(
-                    dim=inner_dim,
-                    num_attention_heads=num_attention_heads,
-                    attention_head_dim=attention_head_dim,
-                    attention_block_types=attention_block_types,
-                    dropout=dropout,
-                    norm_num_groups=norm_num_groups,
-                    cross_attention_dim=cross_attention_dim,
-                    activation_fn=activation_fn,
-                    attention_bias=attention_bias,
-                    upcast_attention=upcast_attention,
-                    cross_frame_attention_mode=cross_frame_attention_mode,
-                    temporal_position_encoding=temporal_position_encoding,
-                    temporal_position_encoding_max_len=temporal_position_encoding_max_len,
-                    ops=ops,
-                )
-                for d in range(num_layers)
-            ]
-        )
-        self.proj_out = ops.Linear(inner_dim, in_channels)
-
-    def set_video_length(self, video_length: int, full_length: int):
-        self.video_length = video_length
-        self.full_length = full_length
-    
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        for block in self.transformer_blocks:
-            block.set_scale_multiplier(multiplier)
-
-    def set_masks(self, masks: Tensor, min_val: float, max_val: float):
-        self.scale_min = min_val
-        self.scale_max = max_val
-        self.raw_scale_mask = masks
-
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        self.sub_idxs = sub_idxs
-        for block in self.transformer_blocks:
-            block.set_sub_idxs(sub_idxs)
-
-    def reset_temp_vars(self):
-        del self.temp_scale_mask
-        self.temp_scale_mask = None
-        self.prev_hidden_states_batch = 0
-        for block in self.transformer_blocks:
-            block.reset_temp_vars()
-
-    def get_scale_mask(self, hidden_states: Tensor) -> Union[Tensor, None]:
-        # if no raw mask, return None
-        if self.raw_scale_mask is None:
-            return None
-        shape = hidden_states.shape
-        batch, channel, height, width = shape
-        # if temp mask already calculated, return it
-        if self.temp_scale_mask != None:
-            # check if hidden_states batch matches
-            if batch == self.prev_hidden_states_batch:
-                if self.sub_idxs is not None:
-                    return self.temp_scale_mask[:, self.sub_idxs, :]
-                return self.temp_scale_mask
-            # if does not match, reset cached temp_scale_mask and recalculate it
-            del self.temp_scale_mask
-            self.temp_scale_mask = None
-        # otherwise, calculate temp mask
-        self.prev_hidden_states_batch = batch
-        mask = prepare_mask_batch(self.raw_scale_mask, shape=(self.full_length, 1, height, width))
-        mask = extend_to_batch_size(mask, self.full_length)
-        # if mask not the same amount length as full length, make it match
-        if self.full_length != mask.shape[0]:
-            mask = broadcast_image_to_extend(mask, self.full_length, 1)
-        # reshape mask to attention K shape (h*w, latent_count, 1)
-        batch, channel, height, width = mask.shape
-        # first, perform same operations as on hidden_states,
-        # turning (b, c, h, w) -> (b, h*w, c)
-        mask = mask.permute(0, 2, 3, 1).reshape(batch, height*width, channel)
-        # then, make it the same shape as attention's k, (h*w, b, c)
-        mask = mask.permute(1, 0, 2)
-        # make masks match the expected length of h*w
-        batched_number = shape[0] // self.video_length
-        if batched_number > 1:
-            mask = torch.cat([mask] * batched_number, dim=0)
-        # cache mask and set to proper device
-        self.temp_scale_mask = mask
-        # move temp_scale_mask to proper dtype + device
-        self.temp_scale_mask = self.temp_scale_mask.to(dtype=hidden_states.dtype, device=hidden_states.device)
-        # return subset of masks, if needed
-        if self.sub_idxs is not None:
-            return self.temp_scale_mask[:, self.sub_idxs, :]
-        return self.temp_scale_mask
-
-    def forward(self, hidden_states, encoder_hidden_states=None, attention_mask=None):
-        batch, channel, height, width = hidden_states.shape
-        residual = hidden_states
-        scale_mask = self.get_scale_mask(hidden_states)
-        # add some casts for fp8 purposes - does not affect speed otherwise
-        hidden_states = self.norm(hidden_states).to(hidden_states.dtype)
-        inner_dim = hidden_states.shape[1]
-        hidden_states = hidden_states.permute(0, 2, 3, 1).reshape(
-            batch, height * width, inner_dim
-        )
-        hidden_states = self.proj_in(hidden_states).to(hidden_states.dtype)
-
-        # Transformer Blocks
-        for block in self.transformer_blocks:
-            hidden_states = block(
-                hidden_states,
-                encoder_hidden_states=encoder_hidden_states,
-                attention_mask=attention_mask,
-                video_length=self.video_length,
-                scale_mask=scale_mask
-            )
-
-        # output
-        hidden_states = self.proj_out(hidden_states)
-        hidden_states = (
-            hidden_states.reshape(batch, height, width, inner_dim)
-            .permute(0, 3, 1, 2)
-            .contiguous()
-        )
-
-        output = hidden_states + residual
-
-        return output
-
-
-class TemporalTransformerBlock(nn.Module):
-    def __init__(
-        self,
-        dim,
-        num_attention_heads,
-        attention_head_dim,
-        attention_block_types=(
-            "Temporal_Self",
-            "Temporal_Self",
-        ),
-        dropout=0.0,
-        norm_num_groups=32,
-        cross_attention_dim=768,
-        activation_fn="geglu",
-        attention_bias=False,
-        upcast_attention=False,
-        cross_frame_attention_mode=None,
-        temporal_position_encoding=False,
-        temporal_position_encoding_max_len=24,
-        ops=disable_weight_init_clean_groupnorm,
-    ):
-        super().__init__()
-
-        attention_blocks = []
-        norms = []
-
-        for block_name in attention_block_types:
-            attention_blocks.append(
-                VersatileAttention(
-                    attention_mode=block_name.split("_")[0],
-                    context_dim=cross_attention_dim # called context_dim for ComfyUI impl
-                    if block_name.endswith("_Cross")
-                    else None,
-                    query_dim=dim,
-                    heads=num_attention_heads,
-                    dim_head=attention_head_dim,
-                    dropout=dropout,
-                    #bias=attention_bias, # remove for Comfy CrossAttention
-                    #upcast_attention=upcast_attention, # remove for Comfy CrossAttention
-                    cross_frame_attention_mode=cross_frame_attention_mode,
-                    temporal_position_encoding=temporal_position_encoding,
-                    temporal_position_encoding_max_len=temporal_position_encoding_max_len,
-                    ops=ops,
-                )
-            )
-            norms.append(ops.LayerNorm(dim))
-
-        self.attention_blocks: Iterable[VersatileAttention] = nn.ModuleList(attention_blocks)
-        self.norms = nn.ModuleList(norms)
-
-        self.ff = FeedForward(dim, dropout=dropout, glu=(activation_fn == "geglu"), operations=ops)
-        self.ff_norm = ops.LayerNorm(dim)
-
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        for block in self.attention_blocks:
-            block.set_scale_multiplier(multiplier)
-
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        for block in self.attention_blocks:
-            block.set_sub_idxs(sub_idxs)
-
-    def reset_temp_vars(self):
-        for block in self.attention_blocks:
-            block.reset_temp_vars()
-
-    def forward(
-        self,
-        hidden_states,
-        encoder_hidden_states=None,
-        attention_mask=None,
-        video_length=None,
-        scale_mask=None
-    ):
-        for attention_block, norm in zip(self.attention_blocks, self.norms):
-            norm_hidden_states = norm(hidden_states).to(hidden_states.dtype)
-            hidden_states = (
-                attention_block(
-                    norm_hidden_states,
-                    encoder_hidden_states=encoder_hidden_states
-                    if attention_block.is_cross_attention
-                    else None,
-                    attention_mask=attention_mask,
-                    video_length=video_length,
-                    scale_mask=scale_mask
-                )
-                + hidden_states
-            )
-
-        hidden_states = self.ff(self.ff_norm(hidden_states)) + hidden_states
-
-        output = hidden_states
-        return output
-
-
-class PositionalEncoding(nn.Module):
-    def __init__(self, d_model, dropout=0.0, max_len=24):
-        super().__init__()
-        self.dropout = nn.Dropout(p=dropout)
-        position = torch.arange(max_len).unsqueeze(1)
-        div_term = torch.exp(
-            torch.arange(0, d_model, 2) * (-math.log(10000.0) / d_model)
-        )
-        pe = torch.zeros(1, max_len, d_model)
-        pe[0, :, 0::2] = torch.sin(position * div_term)
-        pe[0, :, 1::2] = torch.cos(position * div_term)
-        self.register_buffer("pe", pe)
-        self.sub_idxs = None
-
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        self.sub_idxs = sub_idxs
-
-    def forward(self, x):
-        #if self.sub_idxs is not None:
-        #    x = x + self.pe[:, self.sub_idxs]
-        #else:
-        x = x + self.pe[:, : x.size(1)]
-        return self.dropout(x)
-
-
-class CrossAttentionMMSparse(nn.Module):
-    def __init__(self, query_dim, context_dim=None, heads=8, dim_head=64, dropout=0., dtype=None, device=None,
-                 operations=disable_weight_init_clean_groupnorm):
-        super().__init__()
-        inner_dim = dim_head * heads
-        context_dim = default(context_dim, query_dim)
-
-        self.actual_attention = optimized_attention_mm
-        self.heads = heads
-        self.dim_head = dim_head
-        self.scale = None
-
-        self.to_q = operations.Linear(query_dim, inner_dim, bias=False, dtype=dtype, device=device)
-        self.to_k = operations.Linear(context_dim, inner_dim, bias=False, dtype=dtype, device=device)
-        self.to_v = operations.Linear(context_dim, inner_dim, bias=False, dtype=dtype, device=device)
-
-        self.to_out = nn.Sequential(operations.Linear(inner_dim, query_dim, dtype=dtype, device=device), nn.Dropout(dropout))
-
-    def reset_attention_type(self):
-        self.actual_attention = optimized_attention_mm
-
-    def forward(self, x, context=None, value=None, mask=None, scale_mask=None):
-        q = self.to_q(x)
-        context = default(context, x)
-        k: Tensor = self.to_k(context)
-        if value is not None:
-            v = self.to_v(value)
-            del value
-        else:
-            v = self.to_v(context)
-
-        # apply custom scale by multiplying k by scale factor
-        if self.scale is not None:
-            k *= self.scale
-        
-        # apply scale mask, if present
-        if scale_mask is not None:
-            k *= scale_mask
-
-        try:
-            out = self.actual_attention(q, k, v, self.heads, mask)
-        except RuntimeError as e:
-            if str(e).startswith("CUDA error: invalid configuration argument"):
-                self.actual_attention = fallback_attention_mm
-                out = self.actual_attention(q, k, v, self.heads, mask)
-            else:
-                raise
-        return self.to_out(out)
-
-
-class VersatileAttention(CrossAttentionMMSparse):
-    def __init__(
-        self,
-        attention_mode=None,
-        cross_frame_attention_mode=None,
-        temporal_position_encoding=False,
-        temporal_position_encoding_max_len=24,
-        ops=disable_weight_init_clean_groupnorm,
-        *args,
-        **kwargs,
-    ):
-        super().__init__(operations=ops, *args, **kwargs)
-        assert attention_mode == "Temporal"
-
-        self.attention_mode = attention_mode
-        self.is_cross_attention = kwargs["context_dim"] is not None
-
-        self.pos_encoder = (
-            PositionalEncoding(
-                kwargs["query_dim"],
-                dropout=0.0,
-                max_len=temporal_position_encoding_max_len,
-            )
-            if (temporal_position_encoding and attention_mode == "Temporal")
-            else None
-        )
-
-    def extra_repr(self):
-        return f"(Module Info) Attention_Mode: {self.attention_mode}, Is_Cross_Attention: {self.is_cross_attention}"
-
-    def set_scale_multiplier(self, multiplier: Union[float, None]):
-        if multiplier is None or math.isclose(multiplier, 1.0):
-            self.scale = None
-        else:
-            self.scale = multiplier
-
-    def set_sub_idxs(self, sub_idxs: list[int]):
-        if self.pos_encoder != None:
-            self.pos_encoder.set_sub_idxs(sub_idxs)
-
-    def reset_temp_vars(self):
-        self.reset_attention_type()
-
-    def forward(
-        self,
-        hidden_states: Tensor,
-        encoder_hidden_states=None,
-        attention_mask=None,
-        video_length=None,
-        scale_mask=None,
-    ):
-        if self.attention_mode != "Temporal":
-            raise NotImplementedError
-
-        d = hidden_states.shape[1]
-        hidden_states = rearrange(
-            hidden_states, "(b f) d c -> (b d) f c", f=video_length
-        )
-
-        if self.pos_encoder is not None:
-           hidden_states = self.pos_encoder(hidden_states).to(hidden_states.dtype)
-
-        encoder_hidden_states = (
-            repeat(encoder_hidden_states, "b n c -> (b d) n c", d=d)
-            if encoder_hidden_states is not None
-            else encoder_hidden_states
-        )
-
-        hidden_states = super().forward(
-            hidden_states,
-            encoder_hidden_states,
-            value=None,
-            mask=attention_mask,
-            scale_mask=scale_mask,
-        )
-
-        hidden_states = rearrange(hidden_states, "(b d) f c -> (b f) d c", d=d)
-
-        return hidden_states

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -12,27 +12,51 @@
 ####################################################################################################
 from __future__ import annotations
 import comfy.hooks
-from comfy.patcher_extension import WrappersMP
-
-from .sampling import acn_outer_sample_wrapper
-from .utils import WrapperConsts
 
 DINKLINK = "__DINKLINK"
 
+
 def init_dinklink():
-    if not hasattr(comfy.hooks, DINKLINK):
-        setattr(comfy.hooks, DINKLINK, {})
+    create_dinklink()
     prepare_dinklink()
 
+def create_dinklink():
+    if not hasattr(comfy.hooks, DINKLINK):
+        setattr(comfy.hooks, DINKLINK, {})
 
 def get_dinklink() -> dict[str, dict[str]]:
+    create_dinklink()
     return getattr(comfy.hooks, DINKLINK)
 
+
+class DinkLinkConst:
+    VERSION = "version"
+    # ADE
+    ADE = "ADE"
+    ADE_ANIMATEDIFFMODEL = "AnimateDiffModel"
+    ADE_ANIMATEDIFFINFO = "AnimateDiffInfo"
+
 def prepare_dinklink():
-    # expose acn_sampler_sample_wrapper
+    pass
+
+def get_AnimateDiffModel(throw_exception=True):
     d = get_dinklink()
-    link_acn = d.setdefault(WrapperConsts.ACN, {})
-    link_acn[WrapperConsts.VERSION] = 1
-    link_acn[WrapperConsts.ACN_CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.OUTER_SAMPLE,
-                                                             WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY,
-                                                             acn_outer_sample_wrapper)
+    try:
+        link_ade = d[DinkLinkConst.ADE]
+        return link_ade[DinkLinkConst.ADE_ANIMATEDIFFMODEL]
+    except KeyError:
+        if throw_exception:
+            raise Exception("Could not get AnimateDiffModel class. AnimateDiff-Evolved nodes need to be installed to use SparseCtrl; " + \
+                            "they are either not installed or are of an insufficient version.")
+    return None
+
+def get_AnimateDiffInfo(throw_exception=True):
+    d = get_dinklink()
+    try:
+        link_ade = d[DinkLinkConst.ADE]
+        return link_ade[DinkLinkConst.ADE_ANIMATEDIFFINFO]
+    except KeyError:
+        if throw_exception:
+            raise Exception("Could not get AnimateDiffInfo class - AnimateDiff-Evolved nodes need to be installed to use SparseCtrl; " + \
+                            "they are either not installed or are of an insufficient version.")
+    return None

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -11,6 +11,10 @@
 # purposely exposing node pack classes/functions with other node packs.
 ####################################################################################################
 from __future__ import annotations
+from typing import Union
+from torch import Tensor, nn
+
+from comfy.model_patcher import ModelPatcher
 import comfy.hooks
 
 DINKLINK = "__DINKLINK"
@@ -35,9 +39,55 @@ class DinkLinkConst:
     ADE = "ADE"
     ADE_ANIMATEDIFFMODEL = "AnimateDiffModel"
     ADE_ANIMATEDIFFINFO = "AnimateDiffInfo"
+    ADE_CREATE_MOTIONMODELPATCHER = "create_MotionModelPatcher"
 
 def prepare_dinklink():
     pass
+
+
+class InterfaceAnimateDiffInfo:
+    '''Class only used for IDE type hints; interface of ADE's AnimateDiffInfo'''
+    def __init__(self, sd_type: str, mm_format: str, mm_version: str, mm_name: str):
+        self.sd_type = sd_type
+        self.mm_format = mm_format
+        self.mm_version = mm_version
+        self.mm_name = mm_name
+
+
+class InterfaceAnimateDiffModel(nn.Module):
+    '''Class only used for IDE type hints; interface of ADE's AnimateDiffModel'''
+    def __init__(self, mm_state_dict: dict[str, Tensor], mm_info: InterfaceAnimateDiffInfo, init_kwargs: dict[str]={}):
+        pass
+
+    def set_video_length(self, video_length: int, full_length: int) -> None:
+        raise NotImplemented()
+
+    def set_scale(self, scale: Union[float, Tensor, None], per_block_list: Union[list, None]=None) -> None:
+        raise NotImplemented()
+
+    def set_effect(self, multival: Union[float, Tensor, None], per_block_list: Union[list, None]=None) -> None:
+        raise NotImplemented()
+
+    def cleanup(self):
+        raise NotImplemented()
+
+    def inject(self, model: ModelPatcher):
+        pass
+
+    def eject(self, model: ModelPatcher):
+        pass
+
+
+def get_CreateMotionModelPatcher(throw_exception=True):
+    d = get_dinklink()
+    try:
+        link_ade = d[DinkLinkConst.ADE]
+        return link_ade[DinkLinkConst.ADE_CREATE_MOTIONMODELPATCHER]
+    except KeyError:
+        if throw_exception:
+            raise Exception("Could not get create_MotionModelPatcher function. AnimateDiff-Evolved nodes need to be installed to use SparseCtrl; " + \
+                            "they are either not installed or are of an insufficient version.")
+    return None
 
 def get_AnimateDiffModel(throw_exception=True):
     d = get_dinklink()
@@ -50,7 +100,7 @@ def get_AnimateDiffModel(throw_exception=True):
                             "they are either not installed or are of an insufficient version.")
     return None
 
-def get_AnimateDiffInfo(throw_exception=True):
+def get_AnimateDiffInfo(throw_exception=True) -> InterfaceAnimateDiffInfo:
     d = get_dinklink()
     try:
         link_ade = d[DinkLinkConst.ADE]

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -12,6 +12,8 @@
 ####################################################################################################
 from __future__ import annotations
 import comfy.hooks
+from comfy.patcher_extension import WrappersMP
+
 from .sampling import acn_sampler_sample_wrapper
 
 DINKLINK = "__DINKLINK"
@@ -27,9 +29,12 @@ def get_dinklink() -> dict[str, dict[str]]:
 
 class Consts:
     ACN = "ACN"
+    VERSION = "version"
     CREATE_SAMPLER_SAMPLE_WRAPPER = "create_sampler_sample_wrapper"
 
 def prepare_dinklink():
     # expose acn_sampler_sample_wrapper
     d = get_dinklink()
-    d.setdefault(Consts.ACN, {})[Consts.CREATE_SAMPLER_SAMPLE_WRAPPER] = None
+    link_acn = d.setdefault(Consts.ACN, {})
+    link_acn[Consts.VERSION] = 1
+    link_acn[Consts.CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.SAMPLER_SAMPLE, Consts.ACN, acn_sampler_sample_wrapper)

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -15,6 +15,7 @@ import comfy.hooks
 from comfy.patcher_extension import WrappersMP
 
 from .sampling import acn_sampler_sample_wrapper
+from .utils import WrapperConsts
 
 DINKLINK = "__DINKLINK"
 
@@ -27,14 +28,11 @@ def init_dinklink():
 def get_dinklink() -> dict[str, dict[str]]:
     return getattr(comfy.hooks, DINKLINK)
 
-class Consts:
-    ACN = "ACN"
-    VERSION = "version"
-    CREATE_SAMPLER_SAMPLE_WRAPPER = "create_sampler_sample_wrapper"
-
 def prepare_dinklink():
     # expose acn_sampler_sample_wrapper
     d = get_dinklink()
-    link_acn = d.setdefault(Consts.ACN, {})
-    link_acn[Consts.VERSION] = 1
-    link_acn[Consts.CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.SAMPLER_SAMPLE, Consts.ACN, acn_sampler_sample_wrapper)
+    link_acn = d.setdefault(WrapperConsts.ACN, {})
+    link_acn[WrapperConsts.VERSION] = 1
+    link_acn[WrapperConsts.CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.SAMPLER_SAMPLE,
+                                                             WrapperConsts.ACN_SAMPLER_SAMPLER_WRAPPER_KEY,
+                                                             acn_sampler_sample_wrapper)

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import comfy.hooks
 from comfy.patcher_extension import WrappersMP
 
-from .sampling import acn_sampler_sample_wrapper
+from .sampling import acn_outer_sample_wrapper
 from .utils import WrapperConsts
 
 DINKLINK = "__DINKLINK"
@@ -33,6 +33,6 @@ def prepare_dinklink():
     d = get_dinklink()
     link_acn = d.setdefault(WrapperConsts.ACN, {})
     link_acn[WrapperConsts.VERSION] = 1
-    link_acn[WrapperConsts.CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.SAMPLER_SAMPLE,
-                                                             WrapperConsts.ACN_SAMPLER_SAMPLER_WRAPPER_KEY,
-                                                             acn_sampler_sample_wrapper)
+    link_acn[WrapperConsts.ACN_CREATE_SAMPLER_SAMPLE_WRAPPER] = (WrappersMP.OUTER_SAMPLE,
+                                                             WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY,
+                                                             acn_outer_sample_wrapper)

--- a/adv_control/dinklink.py
+++ b/adv_control/dinklink.py
@@ -1,0 +1,35 @@
+####################################################################################################
+# DinkLink is my method of sharing classes/functions between my nodes.
+#
+# My DinkLink-compatible nodes will inject comfy.hooks with a __DINKLINK attr
+# that stores a dictionary, where any of my node packs can store their stuff.
+#
+# It is not intended to be accessed by node packs that I don't develop, so things may change
+# at any time.
+#
+# DinkLink also serves as a proof-of-concept for a future ComfyUI implementation of
+# purposely exposing node pack classes/functions with other node packs.
+####################################################################################################
+from __future__ import annotations
+import comfy.hooks
+from .sampling import acn_sampler_sample_wrapper
+
+DINKLINK = "__DINKLINK"
+
+def init_dinklink():
+    if not hasattr(comfy.hooks, DINKLINK):
+        setattr(comfy.hooks, DINKLINK, {})
+    prepare_dinklink()
+
+
+def get_dinklink() -> dict[str, dict[str]]:
+    return getattr(comfy.hooks, DINKLINK)
+
+class Consts:
+    ACN = "ACN"
+    CREATE_SAMPLER_SAMPLE_WRAPPER = "create_sampler_sample_wrapper"
+
+def prepare_dinklink():
+    # expose acn_sampler_sample_wrapper
+    d = get_dinklink()
+    d.setdefault(Consts.ACN, {})[Consts.CREATE_SAMPLER_SAMPLE_WRAPPER] = None

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -20,8 +20,8 @@ from .logger import logger
 
 from .sampling import acn_sample_factory
 # inject sample functions
-comfy.sample.sample = acn_sample_factory(comfy.sample.sample)
-comfy.sample.sample_custom = acn_sample_factory(comfy.sample.sample_custom, is_custom=True)
+#comfy.sample.sample = acn_sample_factory(comfy.sample.sample)
+#comfy.sample.sample_custom = acn_sample_factory(comfy.sample.sample_custom, is_custom=True)
 
 
 # NODE MAPPING

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -145,11 +145,13 @@ class AdvancedControlNetApply:
                         if is_advanced_controlnet(c_net):
                             # disarm node check
                             c_net.disarm()
-                            # if model required, verify model is passed in, and if so patch it
-                            if c_net.require_model:
-                                if not model_optional:
-                                    raise Exception(f"Type '{type(c_net).__name__}' requires model_optional input, but got None.")
-                                c_net.patch_model(model=model_optional)
+                            # check for allow_condhint_latents where vae_optional can't handle it itself
+                            if c_net.allow_condhint_latents and not c_net.require_vae:
+                                if not isinstance(control_hint, AbstractPreprocWrapper):
+                                    raise Exception(f"Type '{type(c_net).__name__}' requires proc_IMAGE input via a corresponding preprocessor, but received a normal Image instead.")
+                            else:
+                                if isinstance(control_hint, AbstractPreprocWrapper) and not c_net.postpone_condhint_latents_check:
+                                    raise Exception(f"Type '{type(c_net).__name__}' requires a normal Image input, but received a proc_IMAGE input instead.")
                             # if vae required, verify vae is passed in
                             if c_net.require_vae:
                                 # if controlnet can accept preprocced condhint latents and is the case, ignore vae requirement

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -140,6 +140,9 @@ class AdvancedControlNetApply:
                     if prev_cnet in cnets:
                         c_net = cnets[prev_cnet]
                     else:
+                        # make sure control_net is not None to avoid confusing error messages
+                        if control_net is None:
+                            raise Exception("Passed in control_net is None; something must have went wrong when loading it from a Load ControlNet node.")
                         # copy, convert to advanced if needed, and set cond
                         c_net = convert_to_advanced(control_net.copy()).set_cond_hint(control_hint, strength, (start_percent, end_percent), vae_optional)
                         if is_advanced_controlnet(c_net):

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -1,12 +1,4 @@
-import numpy as np
-from torch import Tensor
-
-import folder_paths
 import comfy.sample
-from comfy.model_patcher import ModelPatcher
-
-from .control import load_controlnet, convert_to_advanced, is_advanced_controlnet, is_sd3_advanced_controlnet
-from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, AbstractPreprocWrapper, BIGMAX
 
 from .nodes_main import (ControlNetLoaderAdvanced, DiffControlNetLoaderAdvanced,
                          AdvancedControlNetApply, AdvancedControlNetApplySingle)

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -22,7 +22,8 @@ from .nodes_loosecontrol import ControlNetLoaderWithLoraAdvanced
 from .nodes_deprecated import (LoadImagesFromDirectory, ScaledSoftUniversalWeightsDeprecated,
                                SoftControlNetWeightsDeprecated, CustomControlNetWeightsDeprecated, 
                                SoftT2IAdapterWeightsDeprecated, CustomT2IAdapterWeightsDeprecated,
-                               AdvancedControlNetApplyDEPR, AdvancedControlNetApplySingleDEPR)
+                               AdvancedControlNetApplyDEPR, AdvancedControlNetApplySingleDEPR,
+                               ControlNetLoaderAdvancedDEPR, DiffControlNetLoaderAdvancedDEPR)
 from .logger import logger
 
 from .sampling import acn_sample_factory
@@ -45,8 +46,8 @@ NODE_CLASS_MAPPINGS = {
     "ACN_AdvancedControlNetApply_v2": AdvancedControlNetApply,
     "ACN_AdvancedControlNetApplySingle_v2": AdvancedControlNetApplySingle,
     # Loaders
-    "ControlNetLoaderAdvanced": ControlNetLoaderAdvanced,
-    "DiffControlNetLoaderAdvanced": DiffControlNetLoaderAdvanced,
+    "ACN_ControlNetLoaderAdvanced": ControlNetLoaderAdvanced,
+    "ACN_DiffControlNetLoaderAdvanced": DiffControlNetLoaderAdvanced,
     # Weights
     "ACN_ScaledSoftControlNetWeights": ScaledSoftUniversalWeights,
     "ScaledSoftMaskedUniversalWeights": ScaledSoftMaskedUniversalWeights,
@@ -82,6 +83,8 @@ NODE_CLASS_MAPPINGS = {
     "CustomT2IAdapterWeights": CustomT2IAdapterWeightsDeprecated,
     "ACN_AdvancedControlNetApply": AdvancedControlNetApplyDEPR,
     "ACN_AdvancedControlNetApplySingle": AdvancedControlNetApplySingleDEPR,
+    "ControlNetLoaderAdvanced": ControlNetLoaderAdvancedDEPR,
+    "DiffControlNetLoaderAdvanced": DiffControlNetLoaderAdvancedDEPR,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -97,8 +100,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ACN_AdvancedControlNetApply_v2": "Apply Advanced ControlNet 🛂🅐🅒🅝",
     "ACN_AdvancedControlNetApplySingle_v2": "Apply Advanced ControlNet(1) 🛂🅐🅒🅝",
     # Loaders
-    "ControlNetLoaderAdvanced": "Load Advanced ControlNet Model 🛂🅐🅒🅝",
-    "DiffControlNetLoaderAdvanced": "Load Advanced ControlNet Model (diff) 🛂🅐🅒🅝",
+    "ACN_ControlNetLoaderAdvanced": "Load Advanced ControlNet Model 🛂🅐🅒🅝",
+    "ACN_DiffControlNetLoaderAdvanced": "Load Advanced ControlNet Model (diff) 🛂🅐🅒🅝",
     # Weights
     "ACN_ScaledSoftControlNetWeights": "Scaled Soft Weights 🛂🅐🅒🅝",
     "ScaledSoftMaskedUniversalWeights": "Scaled Soft Masked Weights 🛂🅐🅒🅝",
@@ -134,4 +137,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "CustomT2IAdapterWeights": "T2IAdapter Custom Weights 🛂🅐🅒🅝",
     "ACN_AdvancedControlNetApply": "Apply Advanced ControlNet 🛂🅐🅒🅝",
     "ACN_AdvancedControlNetApplySingle": "Apply Advanced ControlNet(1) 🛂🅐🅒🅝",
+    "ControlNetLoaderAdvanced": "Load Advanced ControlNet Model 🛂🅐🅒🅝",
+    "DiffControlNetLoaderAdvanced": "Load Advanced ControlNet Model (diff) 🛂🅐🅒🅝",
 }

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -4,7 +4,7 @@ from .nodes_main import (ControlNetLoaderAdvanced, DiffControlNetLoaderAdvanced,
                          AdvancedControlNetApply, AdvancedControlNetApplySingle)
 from .nodes_weight import (DefaultWeights, ScaledSoftMaskedUniversalWeights, ScaledSoftUniversalWeights,
                            SoftControlNetWeightsSD15, CustomControlNetWeightsSD15, CustomControlNetWeightsFlux,
-                           SoftT2IAdapterWeights, CustomT2IAdapterWeights)
+                           SoftT2IAdapterWeights, CustomT2IAdapterWeights, ExtrasMiddleMultNode)
 from .nodes_keyframes import (LatentKeyframeGroupNode, LatentKeyframeInterpolationNode, LatentKeyframeBatchedGroupNode, LatentKeyframeNode,
                               TimestepKeyframeNode, TimestepKeyframeInterpolationNode, TimestepKeyframeFromStrengthListNode)
 from .nodes_sparsectrl import SparseCtrlMergedLoaderAdvanced, SparseCtrlLoaderAdvanced, SparseIndexMethodNode, SparseSpreadMethodNode, RgbSparseCtrlPreprocessor, SparseWeightExtras
@@ -45,6 +45,7 @@ NODE_CLASS_MAPPINGS = {
     "ACN_SoftT2IAdapterWeights": SoftT2IAdapterWeights,
     "ACN_CustomT2IAdapterWeights": CustomT2IAdapterWeights,
     "ACN_DefaultUniversalWeights": DefaultWeights,
+    "ACN_ExtrasMiddleMult": ExtrasMiddleMultNode,
     # SparseCtrl
     "ACN_SparseCtrlRGBPreprocessor": RgbSparseCtrlPreprocessor,
     "ACN_SparseCtrlLoaderAdvanced": SparseCtrlLoaderAdvanced,
@@ -101,6 +102,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ACN_SoftT2IAdapterWeights": "T2IAdapter Soft Weights 🛂🅐🅒🅝",
     "ACN_CustomT2IAdapterWeights": "T2IAdapter Custom Weights 🛂🅐🅒🅝",
     "ACN_DefaultUniversalWeights": "Default Weights 🛂🅐🅒🅝",
+    "ACN_ExtrasMiddleMult": "Middle Weight Extras 🛂🅐🅒🅝",
     # SparseCtrl
     "ACN_SparseCtrlRGBPreprocessor": "RGB SparseCtrl 🛂🅐🅒🅝",
     "ACN_SparseCtrlLoaderAdvanced": "Load SparseCtrl Model 🛂🅐🅒🅝",

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -10,6 +10,7 @@ from .nodes_keyframes import (LatentKeyframeGroupNode, LatentKeyframeInterpolati
 from .nodes_sparsectrl import SparseCtrlMergedLoaderAdvanced, SparseCtrlLoaderAdvanced, SparseIndexMethodNode, SparseSpreadMethodNode, RgbSparseCtrlPreprocessor, SparseWeightExtras
 from .nodes_reference import ReferenceControlNetNode, ReferenceControlFinetune, ReferencePreprocessorNode
 from .nodes_plusplus import PlusPlusLoaderAdvanced, PlusPlusLoaderSingle, PlusPlusInputNode
+from .nodes_ctrlora import CtrLoRALoader
 from .nodes_loosecontrol import ControlNetLoaderWithLoraAdvanced
 from .nodes_deprecated import (LoadImagesFromDirectory, ScaledSoftUniversalWeightsDeprecated,
                                SoftControlNetWeightsDeprecated, CustomControlNetWeightsDeprecated, 
@@ -55,6 +56,8 @@ NODE_CLASS_MAPPINGS = {
     "ACN_ControlNet++LoaderSingle": PlusPlusLoaderSingle,
     "ACN_ControlNet++LoaderAdvanced": PlusPlusLoaderAdvanced,
     "ACN_ControlNet++InputNode": PlusPlusInputNode,
+    # CtrLoRA
+    "ACN_CtrLoRALoader": CtrLoRALoader,
     # Reference
     "ACN_ReferencePreprocessor": ReferencePreprocessorNode,
     "ACN_ReferenceControlNet": ReferenceControlNetNode,
@@ -109,6 +112,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "ACN_ControlNet++LoaderSingle": "Load ControlNet++ Model (Single) 🛂🅐🅒🅝",
     "ACN_ControlNet++LoaderAdvanced": "Load ControlNet++ Model (Multi) 🛂🅐🅒🅝",
     "ACN_ControlNet++InputNode": "ControlNet++ Input 🛂🅐🅒🅝",
+    # CtrLoRA
+    "ACN_CtrLoRALoader": "Load CtrLoRA Model 🛂🅐🅒🅝",
     # Reference
     "ACN_ReferencePreprocessor": "Reference Preproccessor 🛂🅐🅒🅝",
     "ACN_ReferenceControlNet": "Reference ControlNet 🛂🅐🅒🅝",

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -18,11 +18,6 @@ from .nodes_deprecated import (LoadImagesFromDirectory, ScaledSoftUniversalWeigh
                                ControlNetLoaderAdvancedDEPR, DiffControlNetLoaderAdvancedDEPR)
 from .logger import logger
 
-from .sampling import acn_sample_factory
-# inject sample functions
-#comfy.sample.sample = acn_sample_factory(comfy.sample.sample)
-#comfy.sample.sample_custom = acn_sample_factory(comfy.sample.sample_custom, is_custom=True)
-
 
 # NODE MAPPING
 NODE_CLASS_MAPPINGS = {

--- a/adv_control/nodes.py
+++ b/adv_control/nodes.py
@@ -7,6 +7,9 @@ from comfy.model_patcher import ModelPatcher
 
 from .control import load_controlnet, convert_to_advanced, is_advanced_controlnet, is_sd3_advanced_controlnet
 from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, AbstractPreprocWrapper, BIGMAX
+
+from .nodes_main import (ControlNetLoaderAdvanced, DiffControlNetLoaderAdvanced,
+                         AdvancedControlNetApply, AdvancedControlNetApplySingle)
 from .nodes_weight import (DefaultWeights, ScaledSoftMaskedUniversalWeights, ScaledSoftUniversalWeights,
                            SoftControlNetWeightsSD15, CustomControlNetWeightsSD15, CustomControlNetWeightsFlux,
                            SoftT2IAdapterWeights, CustomT2IAdapterWeights)
@@ -18,220 +21,14 @@ from .nodes_plusplus import PlusPlusLoaderAdvanced, PlusPlusLoaderSingle, PlusPl
 from .nodes_loosecontrol import ControlNetLoaderWithLoraAdvanced
 from .nodes_deprecated import (LoadImagesFromDirectory, ScaledSoftUniversalWeightsDeprecated,
                                SoftControlNetWeightsDeprecated, CustomControlNetWeightsDeprecated, 
-                               SoftT2IAdapterWeightsDeprecated, CustomT2IAdapterWeightsDeprecated)
+                               SoftT2IAdapterWeightsDeprecated, CustomT2IAdapterWeightsDeprecated,
+                               AdvancedControlNetApplyDEPR, AdvancedControlNetApplySingleDEPR)
 from .logger import logger
 
 from .sampling import acn_sample_factory
 # inject sample functions
 comfy.sample.sample = acn_sample_factory(comfy.sample.sample)
 comfy.sample.sample_custom = acn_sample_factory(comfy.sample.sample_custom, is_custom=True)
-
-
-class ControlNetLoaderAdvanced:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "control_net_name": (folder_paths.get_filename_list("controlnet"), ),
-            },
-            "optional": {
-                "tk_optional": ("TIMESTEP_KEYFRAME", ),
-            }
-        }
-
-    RETURN_TYPES = ("CONTROL_NET", )
-    FUNCTION = "load_controlnet"
-
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
-
-    def load_controlnet(self, control_net_name,
-                        tk_optional: TimestepKeyframeGroup=None,
-                        timestep_keyframe: TimestepKeyframeGroup=None,
-                        ):
-        if timestep_keyframe is not None: # backwards compatibility
-            tk_optional = timestep_keyframe
-        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
-        controlnet = load_controlnet(controlnet_path, tk_optional)
-        return (controlnet,)
-    
-
-class DiffControlNetLoaderAdvanced:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "model": ("MODEL",),
-                "control_net_name": (folder_paths.get_filename_list("controlnet"), )
-            },
-            "optional": {
-                "tk_optional": ("TIMESTEP_KEYFRAME", ),
-                "autosize": ("ACNAUTOSIZE", {"padding": 160}),
-            }
-        }
-    
-    RETURN_TYPES = ("CONTROL_NET", )
-    FUNCTION = "load_controlnet"
-
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
-
-    def load_controlnet(self, control_net_name, model,
-                        tk_optional: TimestepKeyframeGroup=None,
-                        timestep_keyframe: TimestepKeyframeGroup=None
-                        ):
-        if timestep_keyframe is not None: # backwards compatibility
-            tk_optional = timestep_keyframe
-        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
-        controlnet = load_controlnet(controlnet_path, tk_optional, model)
-        if is_advanced_controlnet(controlnet):
-            controlnet.verify_all_weights()
-        return (controlnet,)
-
-
-class AdvancedControlNetApply:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "positive": ("CONDITIONING", ),
-                "negative": ("CONDITIONING", ),
-                "control_net": ("CONTROL_NET", ),
-                "image": ("IMAGE", ),
-                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
-                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
-                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001})
-            },
-            "optional": {
-                "mask_optional": ("MASK", ),
-                "timestep_kf": ("TIMESTEP_KEYFRAME", ),
-                "latent_kf_override": ("LATENT_KEYFRAME", ),
-                "weights_override": ("CONTROL_NET_WEIGHTS", ),
-                "model_optional": ("MODEL",),
-                "vae_optional": ("VAE",),
-                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
-            }
-        }
-
-    RETURN_TYPES = ("CONDITIONING","CONDITIONING","MODEL",)
-    RETURN_NAMES = ("positive", "negative", "model_opt")
-    FUNCTION = "apply_controlnet"
-
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
-
-    def apply_controlnet(self, positive, negative, control_net, image, strength, start_percent, end_percent,
-                         mask_optional: Tensor=None, model_optional: ModelPatcher=None, vae_optional=None,
-                         timestep_kf: TimestepKeyframeGroup=None, latent_kf_override: LatentKeyframeGroup=None,
-                         weights_override: ControlWeights=None, control_apply_to_uncond=False):
-        if strength == 0:
-            return (positive, negative, model_optional)
-        if model_optional:
-            model_optional = model_optional.clone()
-
-        control_hint = image.movedim(-1,1)
-        cnets = {}
-
-        out = []
-        for conditioning in [positive, negative]:
-            c = []
-            if conditioning is not None:
-                for t in conditioning:
-                    d = t[1].copy()
-
-                    prev_cnet = d.get('control', None)
-                    if prev_cnet in cnets:
-                        c_net = cnets[prev_cnet]
-                    else:
-                        # make sure control_net is not None to avoid confusing error messages
-                        if control_net is None:
-                            raise Exception("Passed in control_net is None; something must have went wrong when loading it from a Load ControlNet node.")
-                        # copy, convert to advanced if needed, and set cond
-                        c_net = convert_to_advanced(control_net.copy()).set_cond_hint(control_hint, strength, (start_percent, end_percent), vae_optional)
-                        if is_advanced_controlnet(c_net):
-                            # disarm node check
-                            c_net.disarm()
-                            # check for allow_condhint_latents where vae_optional can't handle it itself
-                            if c_net.allow_condhint_latents and not c_net.require_vae:
-                                if not isinstance(control_hint, AbstractPreprocWrapper):
-                                    raise Exception(f"Type '{type(c_net).__name__}' requires proc_IMAGE input via a corresponding preprocessor, but received a normal Image instead.")
-                            else:
-                                if isinstance(control_hint, AbstractPreprocWrapper) and not c_net.postpone_condhint_latents_check:
-                                    raise Exception(f"Type '{type(c_net).__name__}' requires a normal Image input, but received a proc_IMAGE input instead.")
-                            # if vae required, verify vae is passed in
-                            if c_net.require_vae:
-                                # if controlnet can accept preprocced condhint latents and is the case, ignore vae requirement
-                                if c_net.allow_condhint_latents and isinstance(control_hint, AbstractPreprocWrapper):
-                                    pass
-                                elif not vae_optional:
-                                    # make sure SD3 ControlNet will get a special message instead of generic type mention
-                                    if is_sd3_advanced_controlnet:
-                                        raise Exception(f"SD3 ControlNet requires vae_optional input, but got None.")
-                                    else:
-                                        raise Exception(f"Type '{type(c_net).__name__}' requires vae_optional input, but got None.")
-                            # apply optional parameters and overrides, if provided
-                            if timestep_kf is not None:
-                                c_net.set_timestep_keyframes(timestep_kf)
-                            if latent_kf_override is not None:
-                                c_net.latent_keyframe_override = latent_kf_override
-                            if weights_override is not None:
-                                c_net.weights_override = weights_override
-                            # verify weights are compatible
-                            c_net.verify_all_weights()
-                            # set cond hint mask
-                            if mask_optional is not None:
-                                mask_optional = mask_optional.clone()
-                                # if not in the form of a batch, make it so
-                                if len(mask_optional.shape) < 3:
-                                    mask_optional = mask_optional.unsqueeze(0)
-                                c_net.set_cond_hint_mask(mask_optional)
-                        c_net.set_previous_controlnet(prev_cnet)
-                        cnets[prev_cnet] = c_net
-
-                    d['control'] = c_net
-                    d['control_apply_to_uncond'] = control_apply_to_uncond
-                    n = [t[0], d]
-                    c.append(n)
-            out.append(c)
-        return (out[0], out[1], model_optional)
-    
-
-class AdvancedControlNetApplySingle:
-    @classmethod
-    def INPUT_TYPES(s):
-        return {
-            "required": {
-                "conditioning": ("CONDITIONING", ),
-                "control_net": ("CONTROL_NET", ),
-                "image": ("IMAGE", ),
-                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
-                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
-                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001})
-            },
-            "optional": {
-                "mask_optional": ("MASK", ),
-                "timestep_kf": ("TIMESTEP_KEYFRAME", ),
-                "latent_kf_override": ("LATENT_KEYFRAME", ),
-                "weights_override": ("CONTROL_NET_WEIGHTS", ),
-                "model_optional": ("MODEL",),
-                "vae_optional": ("VAE",),
-                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
-            }
-        }
-
-    RETURN_TYPES = ("CONDITIONING","MODEL",)
-    RETURN_NAMES = ("CONDITIONING", "model_opt")
-    FUNCTION = "apply_controlnet"
-
-    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
-
-    def apply_controlnet(self, conditioning, control_net, image, strength, start_percent, end_percent,
-                         mask_optional: Tensor=None, model_optional: ModelPatcher=None, vae_optional=None,
-                         timestep_kf: TimestepKeyframeGroup=None, latent_kf_override: LatentKeyframeGroup=None,
-                         weights_override: ControlWeights=None):
-        values = AdvancedControlNetApply.apply_controlnet(self, positive=conditioning, negative=None, control_net=control_net, image=image,
-                                                          strength=strength, start_percent=start_percent, end_percent=end_percent,
-                                                          mask_optional=mask_optional, model_optional=model_optional, vae_optional=vae_optional,
-                                                          timestep_kf=timestep_kf, latent_kf_override=latent_kf_override, weights_override=weights_override,
-                                                          control_apply_to_uncond=True)
-        return (values[0], values[2])
 
 
 # NODE MAPPING
@@ -245,8 +42,8 @@ NODE_CLASS_MAPPINGS = {
     "LatentKeyframeBatchedGroup": LatentKeyframeBatchedGroupNode,
     "LatentKeyframeGroup": LatentKeyframeGroupNode,
     # Conditioning
-    "ACN_AdvancedControlNetApply": AdvancedControlNetApply,
-    "ACN_AdvancedControlNetApplySingle": AdvancedControlNetApplySingle,
+    "ACN_AdvancedControlNetApply_v2": AdvancedControlNetApply,
+    "ACN_AdvancedControlNetApplySingle_v2": AdvancedControlNetApplySingle,
     # Loaders
     "ControlNetLoaderAdvanced": ControlNetLoaderAdvanced,
     "DiffControlNetLoaderAdvanced": DiffControlNetLoaderAdvanced,
@@ -283,6 +80,8 @@ NODE_CLASS_MAPPINGS = {
     "CustomControlNetWeights": CustomControlNetWeightsDeprecated,
     "SoftT2IAdapterWeights": SoftT2IAdapterWeightsDeprecated,
     "CustomT2IAdapterWeights": CustomT2IAdapterWeightsDeprecated,
+    "ACN_AdvancedControlNetApply": AdvancedControlNetApplyDEPR,
+    "ACN_AdvancedControlNetApplySingle": AdvancedControlNetApplySingleDEPR,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
@@ -295,8 +94,8 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "LatentKeyframeBatchedGroup": "Latent Keyframe From List 🛂🅐🅒🅝",
     "LatentKeyframeGroup": "Latent Keyframe Group 🛂🅐🅒🅝",
     # Conditioning
-    "ACN_AdvancedControlNetApply": "Apply Advanced ControlNet 🛂🅐🅒🅝",
-    "ACN_AdvancedControlNetApplySingle": "Apply Advanced ControlNet(1) 🛂🅐🅒🅝",
+    "ACN_AdvancedControlNetApply_v2": "Apply Advanced ControlNet 🛂🅐🅒🅝",
+    "ACN_AdvancedControlNetApplySingle_v2": "Apply Advanced ControlNet(1) 🛂🅐🅒🅝",
     # Loaders
     "ControlNetLoaderAdvanced": "Load Advanced ControlNet Model 🛂🅐🅒🅝",
     "DiffControlNetLoaderAdvanced": "Load Advanced ControlNet Model (diff) 🛂🅐🅒🅝",
@@ -333,4 +132,6 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     "CustomControlNetWeights": "ControlNet Custom Weights 🛂🅐🅒🅝",
     "SoftT2IAdapterWeights": "T2IAdapter Soft Weights 🛂🅐🅒🅝",
     "CustomT2IAdapterWeights": "T2IAdapter Custom Weights 🛂🅐🅒🅝",
+    "ACN_AdvancedControlNetApply": "Apply Advanced ControlNet 🛂🅐🅒🅝",
+    "ACN_AdvancedControlNetApplySingle": "Apply Advanced ControlNet(1) 🛂🅐🅒🅝",
 }

--- a/adv_control/nodes_ctrlora.py
+++ b/adv_control/nodes_ctrlora.py
@@ -1,0 +1,25 @@
+import folder_paths
+
+from .control_ctrlora import load_ctrlora
+
+
+class CtrLoRALoader:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "base": (folder_paths.get_filename_list("controlnet"), ),
+                "lora": (folder_paths.get_filename_list("controlnet"), ),
+            }
+        }
+    
+    RETURN_TYPES = ("CONTROL_NET",)
+    FUNCTION = "load_controlnet_plusplus"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/ControlNet++"
+
+    def load_controlnet_plusplus(self, base: str, lora: str):
+        base_path = folder_paths.get_full_path("controlnet", base)
+        lora_path = folder_paths.get_full_path("controlnet", lora)
+        controlnet = load_ctrlora(base_path, lora_path)
+        return (controlnet,)

--- a/adv_control/nodes_deprecated.py
+++ b/adv_control/nodes_deprecated.py
@@ -83,6 +83,8 @@ class ScaledSoftUniversalWeightsDeprecated:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -121,6 +123,8 @@ class SoftControlNetWeightsDeprecated:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -165,6 +169,8 @@ class CustomControlNetWeightsDeprecated:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -200,6 +206,8 @@ class SoftT2IAdapterWeightsDeprecated:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -233,6 +241,8 @@ class CustomT2IAdapterWeightsDeprecated:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -272,6 +282,8 @@ class AdvancedControlNetApplyDEPR:
                 "weights_override": ("CONTROL_NET_WEIGHTS", ),
                 "model_optional": ("MODEL",),
                 "vae_optional": ("VAE",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -313,6 +325,8 @@ class AdvancedControlNetApplySingleDEPR:
                 "weights_override": ("CONTROL_NET_WEIGHTS", ),
                 "model_optional": ("MODEL",),
                 "vae_optional": ("VAE",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }

--- a/adv_control/nodes_keyframes.py
+++ b/adv_control/nodes_keyframes.py
@@ -25,6 +25,8 @@ class TimestepKeyframeNode:
                 "inherit_missing": ("BOOLEAN", {"default": True}, ),
                 "guarantee_steps": ("INT", {"default": 1, "min": 0, "max": BIGMAX}),
                 "mask_optional": ("MASK", ),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -82,6 +84,8 @@ class TimestepKeyframeInterpolationNode:
                 "inherit_missing": ("BOOLEAN", {"default": True},),
                 "mask_optional": ("MASK", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -141,6 +145,8 @@ class TimestepKeyframeFromStrengthListNode:
                 "inherit_missing": ("BOOLEAN", {"default": True},),
                 "mask_optional": ("MASK", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -198,6 +204,8 @@ class LatentKeyframeNode:
             },
             "optional": {
                 "prev_latent_kf": ("LATENT_KEYFRAME", ),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -235,7 +243,9 @@ class LatentKeyframeGroupNode:
                 "prev_latent_kf": ("LATENT_KEYFRAME", ),
                 "latent_optional": ("LATENT", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
-                "autosize": ("ACNAUTOSIZE", {"padding": 35}),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
     
@@ -355,7 +365,9 @@ class LatentKeyframeInterpolationNode:
             "optional": {
                 "prev_latent_kf": ("LATENT_KEYFRAME", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
-                "autosize": ("ACNAUTOSIZE", {"padding": 50}),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
 
@@ -426,6 +438,8 @@ class LatentKeyframeBatchedGroupNode:
             "optional": {
                 "prev_latent_kf": ("LATENT_KEYFRAME", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }

--- a/adv_control/nodes_keyframes.py
+++ b/adv_control/nodes_keyframes.py
@@ -82,7 +82,7 @@ class TimestepKeyframeInterpolationNode:
                 "inherit_missing": ("BOOLEAN", {"default": True},),
                 "mask_optional": ("MASK", ),
                 "print_keyframes": ("BOOLEAN", {"default": False}),
-                "autosize": ("ACNAUTOSIZE", {"padding": 50}),
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
     

--- a/adv_control/nodes_main.py
+++ b/adv_control/nodes_main.py
@@ -47,7 +47,9 @@ class DiffControlNetLoaderAdvanced:
             },
             "optional": {
                 "tk_optional": ("TIMESTEP_KEYFRAME", ),
-                "autosize": ("ACNAUTOSIZE", {"padding": 160}),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
     
@@ -88,6 +90,8 @@ class AdvancedControlNetApply:
                 "latent_kf_override": ("LATENT_KEYFRAME", ),
                 "weights_override": ("CONTROL_NET_WEIGHTS", ),
                 "vae_optional": ("VAE",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -189,8 +193,9 @@ class AdvancedControlNetApplySingle:
                 "timestep_kf": ("TIMESTEP_KEYFRAME", ),
                 "latent_kf_override": ("LATENT_KEYFRAME", ),
                 "weights_override": ("CONTROL_NET_WEIGHTS", ),
-                "model_optional": ("MODEL",),
                 "vae_optional": ("VAE",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -202,12 +207,12 @@ class AdvancedControlNetApplySingle:
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
 
     def apply_controlnet(self, conditioning, control_net, image, strength, start_percent, end_percent,
-                         mask_optional: Tensor=None, model_optional: ModelPatcher=None, vae_optional=None,
+                         mask_optional: Tensor=None, vae_optional=None,
                          timestep_kf: TimestepKeyframeGroup=None, latent_kf_override: LatentKeyframeGroup=None,
                          weights_override: ControlWeights=None):
         values = AdvancedControlNetApply.apply_controlnet(self, positive=conditioning, negative=None, control_net=control_net, image=image,
                                                           strength=strength, start_percent=start_percent, end_percent=end_percent,
-                                                          mask_optional=mask_optional, model_optional=model_optional, vae_optional=vae_optional,
+                                                          mask_optional=mask_optional, vae_optional=vae_optional,
                                                           timestep_kf=timestep_kf, latent_kf_override=latent_kf_override, weights_override=weights_override,
                                                           control_apply_to_uncond=True)
         return (values[0],)

--- a/adv_control/nodes_main.py
+++ b/adv_control/nodes_main.py
@@ -14,10 +14,10 @@ class ControlNetLoaderAdvanced:
     def INPUT_TYPES(s):
         return {
             "required": {
-                "control_net_name": (folder_paths.get_filename_list("controlnet"), ),
+                "cnet": (folder_paths.get_filename_list("controlnet"), ),
             },
             "optional": {
-                "tk_optional": ("TIMESTEP_KEYFRAME", ),
+                "_tk_opt": ("TIMESTEP_KEYFRAME", ),
             }
         }
 
@@ -26,14 +26,11 @@ class ControlNetLoaderAdvanced:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
 
-    def load_controlnet(self, control_net_name,
-                        tk_optional: TimestepKeyframeGroup=None,
-                        timestep_keyframe: TimestepKeyframeGroup=None,
+    def load_controlnet(self, cnet,
+                        _tk_opt: TimestepKeyframeGroup=None,
                         ):
-        if timestep_keyframe is not None: # backwards compatibility
-            tk_optional = timestep_keyframe
-        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
-        controlnet = load_controlnet(controlnet_path, tk_optional)
+        controlnet_path = folder_paths.get_full_path("controlnet", cnet)
+        controlnet = load_controlnet(controlnet_path, _tk_opt)
         return (controlnet,)
     
 
@@ -43,10 +40,10 @@ class DiffControlNetLoaderAdvanced:
         return {
             "required": {
                 "model": ("MODEL",),
-                "control_net_name": (folder_paths.get_filename_list("controlnet"), )
+                "cnet": (folder_paths.get_filename_list("controlnet"), )
             },
             "optional": {
-                "tk_optional": ("TIMESTEP_KEYFRAME", ),
+                "_tk_opt": ("TIMESTEP_KEYFRAME", ),
             },
             "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
@@ -58,14 +55,11 @@ class DiffControlNetLoaderAdvanced:
 
     CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
 
-    def load_controlnet(self, control_net_name, model,
-                        tk_optional: TimestepKeyframeGroup=None,
-                        timestep_keyframe: TimestepKeyframeGroup=None
+    def load_controlnet(self, cnet, model,
+                        _tk_opt: TimestepKeyframeGroup=None,
                         ):
-        if timestep_keyframe is not None: # backwards compatibility
-            tk_optional = timestep_keyframe
-        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
-        controlnet = load_controlnet(controlnet_path, tk_optional, model)
+        controlnet_path = folder_paths.get_full_path("controlnet", cnet)
+        controlnet = load_controlnet(controlnet_path, _tk_opt, model)
         if is_advanced_controlnet(controlnet):
             controlnet.verify_all_weights()
         return (controlnet,)

--- a/adv_control/nodes_main.py
+++ b/adv_control/nodes_main.py
@@ -139,7 +139,7 @@ class AdvancedControlNetApply:
                                     pass
                                 elif not vae_optional:
                                     # make sure SD3 ControlNet will get a special message instead of generic type mention
-                                    if is_sd3_advanced_controlnet:
+                                    if is_sd3_advanced_controlnet(c_net):
                                         raise Exception(f"SD3 ControlNet requires vae_optional input, but got None.")
                                     else:
                                         raise Exception(f"Type '{type(c_net).__name__}' requires vae_optional input, but got None.")

--- a/adv_control/nodes_main.py
+++ b/adv_control/nodes_main.py
@@ -1,0 +1,213 @@
+from torch import Tensor
+
+import folder_paths
+from comfy.model_patcher import ModelPatcher
+
+from .control import load_controlnet, convert_to_advanced, is_advanced_controlnet, is_sd3_advanced_controlnet
+from .utils import ControlWeights, LatentKeyframeGroup, TimestepKeyframeGroup, AbstractPreprocWrapper, BIGMAX
+
+from .logger import logger
+
+
+class ControlNetLoaderAdvanced:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "control_net_name": (folder_paths.get_filename_list("controlnet"), ),
+            },
+            "optional": {
+                "tk_optional": ("TIMESTEP_KEYFRAME", ),
+            }
+        }
+
+    RETURN_TYPES = ("CONTROL_NET", )
+    FUNCTION = "load_controlnet"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
+
+    def load_controlnet(self, control_net_name,
+                        tk_optional: TimestepKeyframeGroup=None,
+                        timestep_keyframe: TimestepKeyframeGroup=None,
+                        ):
+        if timestep_keyframe is not None: # backwards compatibility
+            tk_optional = timestep_keyframe
+        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
+        controlnet = load_controlnet(controlnet_path, tk_optional)
+        return (controlnet,)
+    
+
+class DiffControlNetLoaderAdvanced:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "control_net_name": (folder_paths.get_filename_list("controlnet"), )
+            },
+            "optional": {
+                "tk_optional": ("TIMESTEP_KEYFRAME", ),
+                "autosize": ("ACNAUTOSIZE", {"padding": 160}),
+            }
+        }
+    
+    RETURN_TYPES = ("CONTROL_NET", )
+    FUNCTION = "load_controlnet"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
+
+    def load_controlnet(self, control_net_name, model,
+                        tk_optional: TimestepKeyframeGroup=None,
+                        timestep_keyframe: TimestepKeyframeGroup=None
+                        ):
+        if timestep_keyframe is not None: # backwards compatibility
+            tk_optional = timestep_keyframe
+        controlnet_path = folder_paths.get_full_path("controlnet", control_net_name)
+        controlnet = load_controlnet(controlnet_path, tk_optional, model)
+        if is_advanced_controlnet(controlnet):
+            controlnet.verify_all_weights()
+        return (controlnet,)
+
+
+class AdvancedControlNetApply:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "positive": ("CONDITIONING", ),
+                "negative": ("CONDITIONING", ),
+                "control_net": ("CONTROL_NET", ),
+                "image": ("IMAGE", ),
+                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
+                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001})
+            },
+            "optional": {
+                "mask_optional": ("MASK", ),
+                "timestep_kf": ("TIMESTEP_KEYFRAME", ),
+                "latent_kf_override": ("LATENT_KEYFRAME", ),
+                "weights_override": ("CONTROL_NET_WEIGHTS", ),
+                "vae_optional": ("VAE",),
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
+            }
+        }
+
+    RETURN_TYPES = ("CONDITIONING","CONDITIONING",)
+    RETURN_NAMES = ("positive", "negative")
+    FUNCTION = "apply_controlnet"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
+
+    def apply_controlnet(self, positive, negative, control_net, image, strength, start_percent, end_percent,
+                         mask_optional: Tensor=None, vae_optional=None,
+                         timestep_kf: TimestepKeyframeGroup=None, latent_kf_override: LatentKeyframeGroup=None,
+                         weights_override: ControlWeights=None, control_apply_to_uncond=False):
+        if strength == 0:
+            return (positive, negative)
+
+        control_hint = image.movedim(-1,1)
+        cnets = {}
+
+        out = []
+        for conditioning in [positive, negative]:
+            c = []
+            if conditioning is not None:
+                for t in conditioning:
+                    d = t[1].copy()
+
+                    prev_cnet = d.get('control', None)
+                    if prev_cnet in cnets:
+                        c_net = cnets[prev_cnet]
+                    else:
+                        # make sure control_net is not None to avoid confusing error messages
+                        if control_net is None:
+                            raise Exception("Passed in control_net is None; something must have went wrong when loading it from a Load ControlNet node.")
+                        # copy, convert to advanced if needed, and set cond
+                        c_net = convert_to_advanced(control_net.copy()).set_cond_hint(control_hint, strength, (start_percent, end_percent), vae_optional)
+                        if is_advanced_controlnet(c_net):
+                            # disarm node check
+                            c_net.disarm()
+                            # check for allow_condhint_latents where vae_optional can't handle it itself
+                            if c_net.allow_condhint_latents and not c_net.require_vae:
+                                if not isinstance(control_hint, AbstractPreprocWrapper):
+                                    raise Exception(f"Type '{type(c_net).__name__}' requires proc_IMAGE input via a corresponding preprocessor, but received a normal Image instead.")
+                            else:
+                                if isinstance(control_hint, AbstractPreprocWrapper) and not c_net.postpone_condhint_latents_check:
+                                    raise Exception(f"Type '{type(c_net).__name__}' requires a normal Image input, but received a proc_IMAGE input instead.")
+                            # if vae required, verify vae is passed in
+                            if c_net.require_vae:
+                                # if controlnet can accept preprocced condhint latents and is the case, ignore vae requirement
+                                if c_net.allow_condhint_latents and isinstance(control_hint, AbstractPreprocWrapper):
+                                    pass
+                                elif not vae_optional:
+                                    # make sure SD3 ControlNet will get a special message instead of generic type mention
+                                    if is_sd3_advanced_controlnet:
+                                        raise Exception(f"SD3 ControlNet requires vae_optional input, but got None.")
+                                    else:
+                                        raise Exception(f"Type '{type(c_net).__name__}' requires vae_optional input, but got None.")
+                            # apply optional parameters and overrides, if provided
+                            if timestep_kf is not None:
+                                c_net.set_timestep_keyframes(timestep_kf)
+                            if latent_kf_override is not None:
+                                c_net.latent_keyframe_override = latent_kf_override
+                            if weights_override is not None:
+                                c_net.weights_override = weights_override
+                            # verify weights are compatible
+                            c_net.verify_all_weights()
+                            # set cond hint mask
+                            if mask_optional is not None:
+                                mask_optional = mask_optional.clone()
+                                # if not in the form of a batch, make it so
+                                if len(mask_optional.shape) < 3:
+                                    mask_optional = mask_optional.unsqueeze(0)
+                                c_net.set_cond_hint_mask(mask_optional)
+                        c_net.set_previous_controlnet(prev_cnet)
+                        cnets[prev_cnet] = c_net
+
+                    d['control'] = c_net
+                    d['control_apply_to_uncond'] = control_apply_to_uncond
+                    n = [t[0], d]
+                    c.append(n)
+            out.append(c)
+        return (out[0], out[1])
+    
+
+class AdvancedControlNetApplySingle:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "conditioning": ("CONDITIONING", ),
+                "control_net": ("CONTROL_NET", ),
+                "image": ("IMAGE", ),
+                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.01}),
+                "start_percent": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.001}),
+                "end_percent": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.001})
+            },
+            "optional": {
+                "mask_optional": ("MASK", ),
+                "timestep_kf": ("TIMESTEP_KEYFRAME", ),
+                "latent_kf_override": ("LATENT_KEYFRAME", ),
+                "weights_override": ("CONTROL_NET_WEIGHTS", ),
+                "model_optional": ("MODEL",),
+                "vae_optional": ("VAE",),
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
+            }
+        }
+
+    RETURN_TYPES = ("CONDITIONING","MODEL",)
+    RETURN_NAMES = ("CONDITIONING", "model_opt")
+    FUNCTION = "apply_controlnet"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝"
+
+    def apply_controlnet(self, conditioning, control_net, image, strength, start_percent, end_percent,
+                         mask_optional: Tensor=None, model_optional: ModelPatcher=None, vae_optional=None,
+                         timestep_kf: TimestepKeyframeGroup=None, latent_kf_override: LatentKeyframeGroup=None,
+                         weights_override: ControlWeights=None):
+        values = AdvancedControlNetApply.apply_controlnet(self, positive=conditioning, negative=None, control_net=control_net, image=image,
+                                                          strength=strength, start_percent=start_percent, end_percent=end_percent,
+                                                          mask_optional=mask_optional, model_optional=model_optional, vae_optional=vae_optional,
+                                                          timestep_kf=timestep_kf, latent_kf_override=latent_kf_override, weights_override=weights_override,
+                                                          control_apply_to_uncond=True)
+        return (values[0],)

--- a/adv_control/nodes_plusplus.py
+++ b/adv_control/nodes_plusplus.py
@@ -62,8 +62,10 @@ class PlusPlusInputNode:
             },
             "optional": {
                 "prev_plus_input": ("PLUS_INPUT",),
-                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
                 #"strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": BIGMAX, "step": 0.01}),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
     

--- a/adv_control/nodes_sparsectrl.py
+++ b/adv_control/nodes_sparsectrl.py
@@ -134,7 +134,7 @@ class RgbSparseCtrlPreprocessor:
                 "vae": ("VAE", ),
                 "latent_size": ("LATENT", ),
             },
-            "optional": {
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -168,7 +168,9 @@ class SparseWeightExtras:
                 "sparse_hint_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "sparse_nonhint_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
                 "sparse_mask_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}, ),
-                "autosize": ("ACNAUTOSIZE", {"padding": 50}),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
     

--- a/adv_control/nodes_weight.py
+++ b/adv_control/nodes_weight.py
@@ -13,6 +13,8 @@ class DefaultWeights:
         return {
             "optional": {
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -42,6 +44,8 @@ class ScaledSoftMaskedUniversalWeights:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -76,6 +80,8 @@ class ScaledSoftUniversalWeights:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -113,6 +119,8 @@ class SoftControlNetWeightsSD15:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -156,6 +164,8 @@ class CustomControlNetWeightsSD15:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -204,6 +214,8 @@ class CustomControlNetWeightsFlux:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -238,6 +250,8 @@ class SoftT2IAdapterWeights:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }
@@ -267,6 +281,8 @@ class CustomT2IAdapterWeights:
             "optional": {
                 "uncond_multiplier": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}, ),
                 "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
                 "autosize": ("ACNAUTOSIZE", {"padding": 0}),
             }
         }

--- a/adv_control/nodes_weight.py
+++ b/adv_control/nodes_weight.py
@@ -182,7 +182,8 @@ class CustomControlNetWeightsSD15:
         weights_output = [output_0, output_1, output_2, output_3, output_4, output_5, output_6,
                           output_7, output_8, output_9, output_10, output_11]
         weights_middle = [middle_0]
-        weights = ControlWeights.controlnet(weights_output=weights_output, weights_middle=weights_middle, uncond_multiplier=uncond_multiplier, extras=cn_extras)
+        weights = ControlWeights.controlnet(weights_output=weights_output, weights_middle=weights_middle, uncond_multiplier=uncond_multiplier,
+                                            extras=cn_extras, disable_applied_to=True)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -233,7 +234,7 @@ class CustomControlNetWeightsFlux:
         weights_input = [input_0, input_1, input_2, input_3, input_4, input_5,
                          input_6, input_7, input_8, input_9, input_10, input_11,
                          input_12, input_13, input_14, input_15, input_16, input_17, input_18]
-        weights = ControlWeights.controlnet(weights_input=weights_input, uncond_multiplier=uncond_multiplier, extras=cn_extras)
+        weights = ControlWeights.controlnet(weights_input=weights_input, uncond_multiplier=uncond_multiplier, extras=cn_extras, disable_applied_to=True)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
 
 
@@ -297,5 +298,5 @@ class CustomT2IAdapterWeights:
                      uncond_multiplier: float=1.0, cn_extras: dict[str]={}):
         weights = [input_0, input_1, input_2, input_3]
         weights = get_properly_arranged_t2i_weights(weights)
-        weights = ControlWeights.t2iadapter(weights_input=weights, uncond_multiplier=uncond_multiplier, extras=cn_extras)
+        weights = ControlWeights.t2iadapter(weights_input=weights, uncond_multiplier=uncond_multiplier, extras=cn_extras, disable_applied_to=True)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))

--- a/adv_control/nodes_weight.py
+++ b/adv_control/nodes_weight.py
@@ -1,6 +1,6 @@
 from torch import Tensor
 import torch
-from .utils import TimestepKeyframe, TimestepKeyframeGroup, ControlWeights, get_properly_arranged_t2i_weights, linear_conversion
+from .utils import TimestepKeyframe, TimestepKeyframeGroup, ControlWeights, Extras, get_properly_arranged_t2i_weights, linear_conversion
 from .logger import logger
 
 
@@ -300,3 +300,30 @@ class CustomT2IAdapterWeights:
         weights = get_properly_arranged_t2i_weights(weights)
         weights = ControlWeights.t2iadapter(weights_input=weights, uncond_multiplier=uncond_multiplier, extras=cn_extras, disable_applied_to=True)
         return (weights, TimestepKeyframeGroup.default(TimestepKeyframe(control_weights=weights)))
+
+
+class ExtrasMiddleMultNode:
+    @classmethod
+    def INPUT_TYPES(s):
+        return {
+            "required": {
+                "middle_mult": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 10.0, "step": 0.001}),
+            },
+            "optional": {
+                "cn_extras": ("CN_WEIGHTS_EXTRAS",),
+            },
+            "hidden": {
+                "autosize": ("ACNAUTOSIZE", {"padding": 0}),
+            }
+        }
+    
+    RETURN_TYPES = ("CN_WEIGHTS_EXTRAS",)
+    RETURN_NAMES = ("cn_extras",)
+    FUNCTION = "create_extras"
+
+    CATEGORY = "Adv-ControlNet 🛂🅐🅒🅝/weights/extras"
+
+    def create_extras(self, middle_mult: float, cn_extras: dict[str]={}):
+        cn_extras = cn_extras.copy()
+        cn_extras[Extras.MIDDLE_MULT] = middle_mult
+        return (cn_extras,)

--- a/adv_control/sampling.py
+++ b/adv_control/sampling.py
@@ -1,6 +1,7 @@
 from typing import Callable, Union
 
 import comfy.sample
+import comfy.samplers
 from comfy.model_patcher import ModelPatcher
 from comfy.controlnet import ControlBase
 from comfy.ldm.modules.attention import BasicTransformerBlock
@@ -24,46 +25,206 @@ def support_sliding_context_windows(model, positive, negative) -> tuple[bool, di
     return modified, positive, negative
 
 
-def has_sliding_context_windows(model):
-    motion_injection_params = getattr(model, "motion_injection_params", None)
-    if motion_injection_params is None:
-        return False
-    context_options = getattr(motion_injection_params, "context_options")
+def has_sliding_context_windows(model: ModelPatcher):
+    params = model.get_attachment("ADE_params")
+    if params is None:
+        # backwards compatibility
+        params = getattr(model, "motion_injection_params", None)
+        if params is None:
+            return False
+    context_options = getattr(params, "context_options")
     return context_options.context_length is not None
 
 
-def get_contextref_obj(model):
-    motion_injection_params = getattr(model, "motion_injection_params", None)
-    if motion_injection_params is None:
-        return None
-    context_options = getattr(motion_injection_params, "context_options")
+def get_contextref_obj(model: ModelPatcher):
+    params = model.get_attachment("ADE_params")
+    if params is None:
+        # backwards compatibility
+        params = getattr(model, "motion_injection_params", None)
+        if params is None:
+            return None
+    context_options = getattr(params, "context_options")
     extras = getattr(context_options, "extras", None)
     if extras is None:
         return None
     return getattr(extras, "context_ref", None)
 
 
-def acn_sample_factory(orig_comfy_sample: Callable, is_custom=False) -> Callable:
-    def get_refcn(control: ControlBase, order: int=-1):
-        ref_set: set[ReferenceAdvanced] = set()
-        if control is None:
-            return ref_set
-        if type(control) == ReferenceAdvanced and not control.is_context_ref:
-            control.order = order
-            order -= 1
-            ref_set.add(control)
-        ref_set.update(get_refcn(control.previous_controlnet, order=order))
+def get_refcn(control: ControlBase, order: int=-1):
+    ref_set: set[ReferenceAdvanced] = set()
+    if control is None:
         return ref_set
+    if type(control) == ReferenceAdvanced and not control.is_context_ref:
+        control.order = order
+        order -= 1
+        ref_set.add(control)
+    ref_set.update(get_refcn(control.previous_controlnet, order=order))
+    return ref_set
 
-    def get_lllitecn(control: ControlBase):
-        cn_dict: dict[ControlLLLiteAdvanced,None] = {}
-        if control is None:
-            return cn_dict
-        if type(control) == ControlLLLiteAdvanced:
-            cn_dict[control] = None
-        cn_dict.update(get_lllitecn(control.previous_controlnet))
+def get_lllitecn(control: ControlBase):
+    cn_dict: dict[ControlLLLiteAdvanced,None] = {}
+    if control is None:
         return cn_dict
+    if type(control) == ControlLLLiteAdvanced:
+        cn_dict[control] = None
+    cn_dict.update(get_lllitecn(control.previous_controlnet))
+    return cn_dict
 
+def acn_sample_wrapper(executor, guider: comfy.samplers.CFGGuider, *args, **kwargs):
+    controlnets_modified = False
+    orig_conds = guider.conds
+    orig_positive = args[-3]
+    orig_negative = args[-2]
+    try:
+        orig_model_options = model.model_options
+        # check if positive or negative conds contain ref cn
+        positive = args[-3]
+        negative = args[-2]
+        # if context options present, perform some special actions that may be required
+        context_refs = []
+        if has_sliding_context_windows(model):
+            model.model_options = model.model_options.copy()
+            model.model_options["transformer_options"] = model.model_options["transformer_options"].copy()
+            # convert all CNs to Advanced if needed
+            controlnets_modified, positive, negative = support_sliding_context_windows(model, positive, negative)
+            if controlnets_modified:
+                args = list(args)
+                args[-3] = positive
+                args[-2] = negative
+                args = tuple(args)
+            # enable ContextRef, if requested
+            existing_contextref_obj = get_contextref_obj(model)
+            if existing_contextref_obj is not None:
+                context_refs = handle_context_ref_setup(existing_contextref_obj, model.model_options["transformer_options"], positive, negative)
+                controlnets_modified = True
+        # look for Advanced ControlNets that will require intervention to work
+        ref_set = set()
+        lllite_dict: dict[ControlLLLiteAdvanced, None] = {} # dicts preserve insertion order since py3.7
+        if positive is not None:
+            for cond in positive:
+                if "control" in cond[1]:
+                    ref_set.update(get_refcn(cond[1]["control"]))
+                    lllite_dict.update(get_lllitecn(cond[1]["control"]))
+        if negative is not None:
+            for cond in negative:
+                if "control" in cond[1]:
+                    ref_set.update(get_refcn(cond[1]["control"]))
+                    lllite_dict.update(get_lllitecn(cond[1]["control"]))
+        # if lllite found, apply patches to a cloned model_options, and continue
+        if len(lllite_dict) > 0:
+            lllite_list = list(lllite_dict.keys())
+            model.model_options = model.model_options.copy()
+            model.model_options["transformer_options"] = model.model_options["transformer_options"].copy()
+            lllite_list.reverse() # reverse so that patches will be applied in expected order
+            for lll in lllite_list:
+                lll.live_model_patches(model.model_options)
+        # if no ref cn found, do original function immediately
+        if len(ref_set) == 0 and len(context_refs) == 0:
+            return orig_comfy_sample(model, *args, **kwargs)
+        # otherwise, injection time
+        try:
+            # inject
+            # storage for all Reference-related injections
+            reference_injections = ReferenceInjections()
+
+            # first, handle attn module injection
+            all_modules = torch_dfs(model.model)
+            attn_modules: list[RefBasicTransformerBlock] = []
+            for module in all_modules:
+                if isinstance(module, BasicTransformerBlock):
+                    attn_modules.append(module)
+            attn_modules = [module for module in all_modules if isinstance(module, BasicTransformerBlock)]
+            attn_modules = sorted(attn_modules, key=lambda x: -x.norm1.normalized_shape[0])
+            for i, module in enumerate(attn_modules):
+                injection_holder = InjectionBasicTransformerBlockHolder(block=module, idx=i)
+                injection_holder.attn_weight = float(i) / float(len(attn_modules))
+                if hasattr(module, "_forward"): # backward compatibility
+                    module._forward = _forward_inject_BasicTransformerBlock.__get__(module, type(module))
+                else:
+                    module.forward = _forward_inject_BasicTransformerBlock.__get__(module, type(module))
+                module.injection_holder = injection_holder
+                reference_injections.attn_modules.append(module)
+            # figure out which module is middle block
+            if hasattr(model.model.diffusion_model, "middle_block"):
+                mid_modules = torch_dfs(model.model.diffusion_model.middle_block)
+                mid_attn_modules: list[RefBasicTransformerBlock] = [module for module in mid_modules if isinstance(module, BasicTransformerBlock)]
+                for module in mid_attn_modules:
+                    module.injection_holder.is_middle = True
+
+            # next, handle gn module injection (TimestepEmbedSequential)
+            # TODO: figure out the logic behind these hardcoded indexes
+            if type(model.model).__name__ == "SDXL":
+                input_block_indices = [4, 5, 7, 8]
+                output_block_indices = [0, 1, 2, 3, 4, 5]
+            else:
+                input_block_indices = [4, 5, 7, 8, 10, 11]
+                output_block_indices = [0, 1, 2, 3, 4, 5, 6, 7]
+            if hasattr(model.model.diffusion_model, "middle_block"):
+                module = model.model.diffusion_model.middle_block
+                injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=0, is_middle=True)
+                injection_holder.gn_weight = 0.0
+                module.injection_holder = injection_holder
+                reference_injections.gn_modules.append(module)
+            for w, i in enumerate(input_block_indices):
+                module = model.model.diffusion_model.input_blocks[i]
+                injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=i, is_input=True)
+                injection_holder.gn_weight = 1.0 - float(w) / float(len(input_block_indices))
+                module.injection_holder = injection_holder
+                reference_injections.gn_modules.append(module)
+            for w, i in enumerate(output_block_indices):
+                module = model.model.diffusion_model.output_blocks[i]
+                injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=i, is_output=True)
+                injection_holder.gn_weight = float(w) / float(len(output_block_indices))
+                module.injection_holder = injection_holder
+                reference_injections.gn_modules.append(module)
+            # hack gn_module forwards and update weights
+            for i, module in enumerate(reference_injections.gn_modules):
+                module.injection_holder.gn_weight *= 2
+
+            # handle diffusion_model forward injection
+            reference_injections.diffusion_model_orig_forward = model.model.diffusion_model.forward
+            model.model.diffusion_model.forward = factory_forward_inject_UNetModel(reference_injections).__get__(model.model.diffusion_model, type(model.model.diffusion_model))
+            # store ordered ref cns in model's transformer options
+            new_model_options = model.model_options.copy()
+            new_model_options["transformer_options"] = model.model_options["transformer_options"].copy()
+            ref_list: list[ReferenceAdvanced] = list(ref_set)
+            new_model_options["transformer_options"][REF_CONTROL_LIST_ALL] = sorted(ref_list, key=lambda x: x.order)
+            new_model_options["transformer_options"][CONTEXTREF_CLEAN_FUNC] = reference_injections.clean_contextref_module_mem
+            model.model_options = new_model_options
+            # continue with original function
+            return orig_comfy_sample(model, *args, **kwargs)
+        finally:
+            # cleanup injections
+            # restore attn modules
+            attn_modules: list[RefBasicTransformerBlock] = reference_injections.attn_modules
+            for module in attn_modules:
+                module.injection_holder.restore(module)
+                module.injection_holder.clean_all()
+                del module.injection_holder
+            del attn_modules
+            # restore gn modules
+            gn_modules: list[RefTimestepEmbedSequential] = reference_injections.gn_modules
+            for module in gn_modules:
+                module.injection_holder.restore(module)
+                module.injection_holder.clean_all()
+                del module.injection_holder
+            del gn_modules
+            # restore diffusion_model forward function
+            model.model.diffusion_model.forward = reference_injections.diffusion_model_orig_forward.__get__(model.model.diffusion_model, type(model.model.diffusion_model))
+            # cleanup
+            reference_injections.cleanup()
+    finally:
+        # restore model_options
+        model.model_options = orig_model_options
+        # restore controlnets in conds, if needed
+        if controlnets_modified:
+            restore_all_controlnet_conns([orig_positive, orig_negative])
+
+
+
+
+
+def acn_sample_factory(orig_comfy_sample: Callable, is_custom=False) -> Callable:
     def acn_sample(model: ModelPatcher, *args, **kwargs):
         controlnets_modified = False
         orig_positive = args[-3]

--- a/adv_control/sampling.py
+++ b/adv_control/sampling.py
@@ -17,7 +17,18 @@ from .control_reference import (ReferenceAdvanced, ReferenceInjections,
                                 _forward_inject_BasicTransformerBlock,
                                 handle_context_ref_setup, handle_reference_injection,
                                 REF_CONTROL_LIST_ALL, CONTEXTREF_CLEAN_FUNC)
+from .dinklink import get_dinklink
 from .utils import torch_dfs, WrapperConsts
+
+
+def prepare_dinklink_acn_wrapper():
+    # expose acn_sampler_sample_wrapper
+    d = get_dinklink()
+    link_acn = d.setdefault(WrapperConsts.ACN, {})
+    link_acn[WrapperConsts.VERSION] = 10000
+    link_acn[WrapperConsts.ACN_CREATE_SAMPLER_SAMPLE_WRAPPER] = (comfy.patcher_extension.WrappersMP.OUTER_SAMPLE,
+                                                                 WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY,
+                                                                 acn_outer_sample_wrapper)
 
 
 def support_sliding_context_windows(conds) -> tuple[bool, list[dict]]:

--- a/adv_control/sampling.py
+++ b/adv_control/sampling.py
@@ -72,32 +72,31 @@ def get_lllitecn(control: ControlBase):
     cn_dict.update(get_lllitecn(control.previous_controlnet))
     return cn_dict
 
-def should_register_sampler_sampler_wrapper(hook, model, model_options: dict, target, registered: list):
-    wrappers = comfy.patcher_extension.get_wrappers_with_key(comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE,
-                                                  WrapperConsts.ACN_SAMPLER_SAMPLER_WRAPPER_KEY,
+def should_register_outer_sample_wrapper(hook, model, model_options: dict, target, registered: list):
+    wrappers = comfy.patcher_extension.get_wrappers_with_key(comfy.patcher_extension.WrappersMP.OUTER_SAMPLE,
+                                                  WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY,
                                                   model_options, is_model_options=True)
     return len(wrappers) == 0
 
 def create_wrapper_hooks():
     wrappers = {}
-    comfy.patcher_extension.add_wrapper_with_key(comfy.patcher_extension.WrappersMP.SAMPLER_SAMPLE,
-                                                 WrapperConsts.ACN_SAMPLER_SAMPLER_WRAPPER_KEY,
-                                                 acn_sampler_sample_wrapper,
+    comfy.patcher_extension.add_wrapper_with_key(comfy.patcher_extension.WrappersMP.OUTER_SAMPLE,
+                                                 WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY,
+                                                 acn_outer_sample_wrapper,
                                                  transformer_options=wrappers)
     hooks = comfy.hooks.HookGroup()
     hook = comfy.hooks.WrapperHook(wrappers)
-    hook.hook_id = WrapperConsts.ACN_SAMPLER_SAMPLER_WRAPPER_KEY
-    hook.custom_should_register = should_register_sampler_sampler_wrapper
+    hook.hook_id = WrapperConsts.ACN_OUTER_SAMPLE_WRAPPER_KEY
+    hook.custom_should_register = should_register_outer_sample_wrapper
     hooks.add(hook)
     return hooks
 
-def acn_sampler_sample_wrapper(executor, *args, **kwargs):
+def acn_outer_sample_wrapper(executor, *args, **kwargs):
     controlnets_modified = False
-    guider: comfy.samplers.CFGGuider = args[0]
+    guider: comfy.samplers.CFGGuider = executor.class_obj
     model = guider.model_patcher
-    extra_args: dict = args[2]
     orig_conds = guider.conds
-    orig_model_options = extra_args["model_options"]
+    orig_model_options = guider.model_options
     try:
         new_model_options = orig_model_options
         # if context options present, perform some special actions that may be required
@@ -105,13 +104,13 @@ def acn_sampler_sample_wrapper(executor, *args, **kwargs):
         if has_sliding_context_windows(guider.model_patcher):
             new_model_options = comfy.model_patcher.create_model_options_clone(new_model_options)
             # convert all CNs to Advanced if needed
-            controlnets_modified, conds = support_sliding_context_windows(orig_conds.values())
+            controlnets_modified, conds = support_sliding_context_windows(orig_conds)
             if controlnets_modified:
                 guider.conds = conds
             # enable ContextRef, if requested
             existing_contextref_obj = get_contextref_obj(guider.model_patcher)
             if existing_contextref_obj is not None:
-                context_refs = handle_context_ref_setup(existing_contextref_obj, new_model_options["transformer_options"], guider.conds.values())
+                context_refs = handle_context_ref_setup(existing_contextref_obj, new_model_options["transformer_options"], guider.conds)
                 controlnets_modified = True
         # look for Advanced ControlNets that will require intervention to work
         ref_set = set()
@@ -199,7 +198,7 @@ def acn_sampler_sample_wrapper(executor, *args, **kwargs):
             ref_list: list[ReferenceAdvanced] = list(ref_set)
             new_model_options["transformer_options"][REF_CONTROL_LIST_ALL] = sorted(ref_list, key=lambda x: x.order)
             new_model_options["transformer_options"][CONTEXTREF_CLEAN_FUNC] = reference_injections.clean_contextref_module_mem
-            extra_args["model_options"] = new_model_options
+            guider.model_options = new_model_options
             # continue with original function
             return executor(*args, **kwargs)
         finally:
@@ -224,165 +223,13 @@ def acn_sampler_sample_wrapper(executor, *args, **kwargs):
             reference_injections.cleanup()
     finally:
         # restore model_options
-        extra_args["model_options"] = orig_model_options
+        guider.model_options = orig_model_options
         # restore guider.conds
         guider.conds = orig_conds
         # restore controlnets in conds, if needed
         if controlnets_modified:
-            restore_all_controlnet_conns(orig_conds.values())
+            restore_all_controlnet_conns(guider.conds)
+        del orig_conds
+        del orig_model_options
         del model
         del guider
-
-
-def acn_sample_factory(orig_comfy_sample: Callable, is_custom=False) -> Callable:
-    def acn_sample(model: ModelPatcher, *args, **kwargs):
-        controlnets_modified = False
-        orig_positive = args[-3]
-        orig_negative = args[-2]
-        try:
-            orig_model_options = model.model_options
-            # check if positive or negative conds contain ref cn
-            positive = args[-3]
-            negative = args[-2]
-            # if context options present, perform some special actions that may be required
-            context_refs = []
-            if has_sliding_context_windows(model):
-                model.model_options = model.model_options.copy()
-                model.model_options["transformer_options"] = model.model_options["transformer_options"].copy()
-                # convert all CNs to Advanced if needed
-                controlnets_modified, conds = support_sliding_context_windows([positive, negative])
-                positive, negative = conds
-                if controlnets_modified:
-                    args = list(args)
-                    args[-3] = positive
-                    args[-2] = negative
-                    args = tuple(args)
-                # enable ContextRef, if requested
-                existing_contextref_obj = get_contextref_obj(model)
-                if existing_contextref_obj is not None:
-                    context_refs = handle_context_ref_setup(existing_contextref_obj, model.model_options["transformer_options"], [positive, negative])
-                    controlnets_modified = True
-            # look for Advanced ControlNets that will require intervention to work
-            ref_set = set()
-            lllite_dict: dict[ControlLLLiteAdvanced, None] = {} # dicts preserve insertion order since py3.7
-            if positive is not None:
-                for cond in positive:
-                    if "control" in cond[1]:
-                        ref_set.update(get_refcn(cond[1]["control"]))
-                        lllite_dict.update(get_lllitecn(cond[1]["control"]))
-            if negative is not None:
-                for cond in negative:
-                    if "control" in cond[1]:
-                        ref_set.update(get_refcn(cond[1]["control"]))
-                        lllite_dict.update(get_lllitecn(cond[1]["control"]))
-            # if lllite found, apply patches to a cloned model_options, and continue
-            if len(lllite_dict) > 0:
-                lllite_list = list(lllite_dict.keys())
-                model.model_options = model.model_options.copy()
-                model.model_options["transformer_options"] = model.model_options["transformer_options"].copy()
-                lllite_list.reverse() # reverse so that patches will be applied in expected order
-                for lll in lllite_list:
-                    lll.live_model_patches(model.model_options)
-            # if no ref cn found, do original function immediately
-            if len(ref_set) == 0 and len(context_refs) == 0:
-                return orig_comfy_sample(model, *args, **kwargs)
-            # otherwise, injection time
-            try:
-                # inject
-                # storage for all Reference-related injections
-                reference_injections = ReferenceInjections()
-
-                # first, handle attn module injection
-                all_modules = torch_dfs(model.model)
-                attn_modules: list[RefBasicTransformerBlock] = []
-                for module in all_modules:
-                    if isinstance(module, BasicTransformerBlock):
-                        attn_modules.append(module)
-                attn_modules = [module for module in all_modules if isinstance(module, BasicTransformerBlock)]
-                attn_modules = sorted(attn_modules, key=lambda x: -x.norm1.normalized_shape[0])
-                for i, module in enumerate(attn_modules):
-                    injection_holder = InjectionBasicTransformerBlockHolder(block=module, idx=i)
-                    injection_holder.attn_weight = float(i) / float(len(attn_modules))
-                    if hasattr(module, "_forward"): # backward compatibility
-                        module._forward = _forward_inject_BasicTransformerBlock.__get__(module, type(module))
-                    else:
-                        module.forward = _forward_inject_BasicTransformerBlock.__get__(module, type(module))
-                    module.injection_holder = injection_holder
-                    reference_injections.attn_modules.append(module)
-                # figure out which module is middle block
-                if hasattr(model.model.diffusion_model, "middle_block"):
-                    mid_modules = torch_dfs(model.model.diffusion_model.middle_block)
-                    mid_attn_modules: list[RefBasicTransformerBlock] = [module for module in mid_modules if isinstance(module, BasicTransformerBlock)]
-                    for module in mid_attn_modules:
-                        module.injection_holder.is_middle = True
-
-                # next, handle gn module injection (TimestepEmbedSequential)
-                # TODO: figure out the logic behind these hardcoded indexes
-                if type(model.model).__name__ == "SDXL":
-                    input_block_indices = [4, 5, 7, 8]
-                    output_block_indices = [0, 1, 2, 3, 4, 5]
-                else:
-                    input_block_indices = [4, 5, 7, 8, 10, 11]
-                    output_block_indices = [0, 1, 2, 3, 4, 5, 6, 7]
-                if hasattr(model.model.diffusion_model, "middle_block"):
-                    module = model.model.diffusion_model.middle_block
-                    injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=0, is_middle=True)
-                    injection_holder.gn_weight = 0.0
-                    module.injection_holder = injection_holder
-                    reference_injections.gn_modules.append(module)
-                for w, i in enumerate(input_block_indices):
-                    module = model.model.diffusion_model.input_blocks[i]
-                    injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=i, is_input=True)
-                    injection_holder.gn_weight = 1.0 - float(w) / float(len(input_block_indices))
-                    module.injection_holder = injection_holder
-                    reference_injections.gn_modules.append(module)
-                for w, i in enumerate(output_block_indices):
-                    module = model.model.diffusion_model.output_blocks[i]
-                    injection_holder = InjectionTimestepEmbedSequentialHolder(block=module, idx=i, is_output=True)
-                    injection_holder.gn_weight = float(w) / float(len(output_block_indices))
-                    module.injection_holder = injection_holder
-                    reference_injections.gn_modules.append(module)
-                # hack gn_module forwards and update weights
-                for i, module in enumerate(reference_injections.gn_modules):
-                    module.injection_holder.gn_weight *= 2
-
-                # handle diffusion_model forward injection
-                reference_injections.diffusion_model_orig_forward = model.model.diffusion_model.forward
-                model.model.diffusion_model.forward = factory_forward_inject_UNetModel(reference_injections).__get__(model.model.diffusion_model, type(model.model.diffusion_model))
-                # store ordered ref cns in model's transformer options
-                new_model_options = model.model_options.copy()
-                new_model_options["transformer_options"] = model.model_options["transformer_options"].copy()
-                ref_list: list[ReferenceAdvanced] = list(ref_set)
-                new_model_options["transformer_options"][REF_CONTROL_LIST_ALL] = sorted(ref_list, key=lambda x: x.order)
-                new_model_options["transformer_options"][CONTEXTREF_CLEAN_FUNC] = reference_injections.clean_contextref_module_mem
-                model.model_options = new_model_options
-                # continue with original function
-                return orig_comfy_sample(model, *args, **kwargs)
-            finally:
-                # cleanup injections
-                # restore attn modules
-                attn_modules: list[RefBasicTransformerBlock] = reference_injections.attn_modules
-                for module in attn_modules:
-                    module.injection_holder.restore(module)
-                    module.injection_holder.clean_all()
-                    del module.injection_holder
-                del attn_modules
-                # restore gn modules
-                gn_modules: list[RefTimestepEmbedSequential] = reference_injections.gn_modules
-                for module in gn_modules:
-                    module.injection_holder.restore(module)
-                    module.injection_holder.clean_all()
-                    del module.injection_holder
-                del gn_modules
-                # restore diffusion_model forward function
-                model.model.diffusion_model.forward = reference_injections.diffusion_model_orig_forward.__get__(model.model.diffusion_model, type(model.model.diffusion_model))
-                # cleanup
-                reference_injections.cleanup()
-        finally:
-            # restore model_options
-            model.model_options = orig_model_options
-            # restore controlnets in conds, if needed
-            if controlnets_modified:
-                restore_all_controlnet_conns([orig_positive, orig_negative])
-
-    return acn_sample

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -57,6 +57,7 @@ class ControlWeightType:
     CONTROLLLLITE = "controllllite"
     SVD_CONTROLNET = "svd_controlnet"
     SPARSECTRL = "sparsectrl"
+    CTRLORA = "ctrlora"
 
 
 class ControlWeights:
@@ -502,6 +503,7 @@ class AdvancedControlBase:
         self.set_cond_hint = self.set_cond_hint_inject
         # vae to store
         self.adv_vae = None
+        self.mult_by_ratio_when_vae = True
         # require model/vae to be passed into Apply Advanced ControlNet 🛂🅐🅒🅝 node
         self.require_vae = require_vae
         self.allow_condhint_latents = allow_condhint_latents
@@ -615,11 +617,13 @@ class AdvancedControlBase:
             for arg in args:
                 if isinstance(arg, VAE):
                     self.adv_vae = arg
+                    self.vae = arg
                     break
             # if not in args, check kwargs now
             if self.adv_vae is None:
                 if 'vae' in kwargs:
                     self.adv_vae = kwargs['vae']
+                    self.vae = kwargs['vae']
         return to_return
 
     def pre_run_inject(self, model, percent_to_timestep_function):
@@ -876,6 +880,7 @@ class AdvancedControlBase:
         copied.weights_override = self.weights_override
         copied.latent_keyframe_override = self.latent_keyframe_override
         copied.adv_vae = self.adv_vae
+        copied.mult_by_ratio_when_vae = self.mult_by_ratio_when_vae
         copied.require_vae = self.require_vae
         copied.allow_condhint_latents = self.allow_condhint_latents
         copied.postpone_condhint_latents_check = self.postpone_condhint_latents_check

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -457,7 +457,7 @@ class WeightTypeException(TypeError):
 
 
 class AdvancedControlBase:
-    def __init__(self, base: ControlBase, timestep_keyframes: TimestepKeyframeGroup, weights_default: ControlWeights, require_model=False, require_vae=False, allow_condhint_latents=False):
+    def __init__(self, base: ControlBase, timestep_keyframes: TimestepKeyframeGroup, weights_default: ControlWeights, require_vae=False, allow_condhint_latents=False):
         self.base = base
         self.compatible_weights = [ControlWeightType.UNIVERSAL, ControlWeightType.DEFAULT]
         self.add_compatible_weight(weights_default.weight_type)
@@ -496,14 +496,11 @@ class AdvancedControlBase:
         # vae to store
         self.adv_vae = None
         # require model/vae to be passed into Apply Advanced ControlNet 🛂🅐🅒🅝 node
-        self.require_model = require_model
         self.require_vae = require_vae
         self.allow_condhint_latents = allow_condhint_latents
+        self.postpone_condhint_latents_check = False
         # disarm - when set to False, used to force usage of Apply Advanced ControlNet 🛂🅐🅒🅝 node (which will set it to True)
-        self.disarmed = not require_model
-    
-    def patch_model(self, model: ModelPatcher):
-        pass
+        self.disarmed = True
 
     def add_compatible_weight(self, control_weight_type: str):
         self.compatible_weights.append(control_weight_type)
@@ -874,4 +871,5 @@ class AdvancedControlBase:
         copied.adv_vae = self.adv_vae
         copied.require_vae = self.require_vae
         copied.allow_condhint_latents = self.allow_condhint_latents
+        copied.postpone_condhint_latents_check = self.postpone_condhint_latents_check
         copied.disarmed = self.disarmed

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -247,9 +247,10 @@ class TimestepKeyframe:
 
 # always maintain sorted state (by start_percent of TimestepKeyFrame)
 class TimestepKeyframeGroup:
-    def __init__(self) -> None:
+    def __init__(self, add_default=True) -> None:
         self.keyframes: list[TimestepKeyframe] = []
-        self.keyframes.append(TimestepKeyframe.default())
+        if add_default:
+            self.keyframes.append(TimestepKeyframe.default())
 
     def add(self, keyframe: TimestepKeyframe) -> None:
         # add to end of list, then sort
@@ -275,7 +276,7 @@ class TimestepKeyframeGroup:
         return len(self.keyframes) == 0
     
     def clone(self) -> 'TimestepKeyframeGroup':
-        cloned = TimestepKeyframeGroup()
+        cloned = TimestepKeyframeGroup(add_default=False)
         # already sorted, so don't use add function to make cloning quicker
         for tk in self.keyframes:
             cloned.keyframes.append(tk)

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -31,6 +31,13 @@ def load_torch_file_with_dict_factory(controlnet_data: dict[str, Tensor], orig_l
     return load_torch_file_with_dict
 
 
+class WrapperConsts:
+    ACN = "ACN"
+    VERSION = "version"
+    ACN_SAMPLER_SAMPLER_WRAPPER_KEY = "ACN_sampler_sample_wrapper"
+    CREATE_SAMPLER_SAMPLE_WRAPPER = "create_sampler_sample_wrapper"
+
+
 def get_properly_arranged_t2i_weights(initial_weights: list[float]):
     new_weights = []
     new_weights.extend([initial_weights[0]]*3)

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -34,8 +34,8 @@ def load_torch_file_with_dict_factory(controlnet_data: dict[str, Tensor], orig_l
 class WrapperConsts:
     ACN = "ACN"
     VERSION = "version"
-    ACN_SAMPLER_SAMPLER_WRAPPER_KEY = "ACN_sampler_sample_wrapper"
-    CREATE_SAMPLER_SAMPLE_WRAPPER = "create_sampler_sample_wrapper"
+    ACN_OUTER_SAMPLE_WRAPPER_KEY = "ACN_outer_sample_wrapper"
+    ACN_CREATE_SAMPLER_SAMPLE_WRAPPER = "create_outer_sample_wrapper"
 
 
 def get_properly_arranged_t2i_weights(initial_weights: list[float]):

--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -504,6 +504,8 @@ class AdvancedControlBase:
         # vae to store
         self.adv_vae = None
         self.mult_by_ratio_when_vae = True
+        # compression ratio stuff
+        self.real_compression_ratio = None
         # require model/vae to be passed into Apply Advanced ControlNet 🛂🅐🅒🅝 node
         self.require_vae = require_vae
         self.allow_condhint_latents = allow_condhint_latents
@@ -634,6 +636,9 @@ class AdvancedControlBase:
         # for each timestep keyframe, calculate the start_t
         for tk in self.timestep_keyframes.keyframes:
             tk.start_t = percent_to_timestep_function(tk.start_percent)
+        # set real_compression_ratio to compression_ratio
+        if hasattr(self, "compression_ratio"):
+            self.real_compression_ratio = self.compression_ratio
         # clear variables
         self.cleanup_advanced()
 
@@ -857,6 +862,9 @@ class AdvancedControlBase:
         self.batch_size = 0
         self.weights = None
         self.latent_keyframes = None
+        # set effective_compression_ratio to compression_ratio
+        if hasattr(self, "compression_ratio"):
+            self.real_compression_ratio = self.compression_ratio
         # timestep stuff
         self._current_timestep_keyframe = None
         self._current_timestep_index = -1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-advanced-controlnet"
 description = "Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks."
-version = "1.3.0"
+version = "1.4.0"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
Modifies code to use ComfyUI's built-in hooks/wrappers/callbacks system from the PR I submitted, allowing a bunch of hacks to be removed.

Notable changes/features:
- Fix checks for vae requirement, RefCN/RGB Preprocessors
- ReferenceCN and ControlLLLite respect the conditioning they are applied to thanks to the new wrappers system, meaning masked conditioning can allow them to be properly masked
- CtrLoRA support via Load CtrLoRA Model node
- Soft Weights/Custom Weights now work properly with flux by disabling the applied_to optimization
- Support for SD3.5 Controlnets via extending vanilla features - only thing not working is attention masking
- middle_mult control via Middle Weight Extras node