### PR TITLE
Fix CtrLoRA preprocessor

### DIFF
--- a/adv_control/control_ctrlora.py
+++ b/adv_control/control_ctrlora.py
@@ -50,6 +50,7 @@ class ControlNetCtrLoRA(ControlNetCLDM):
 class CtrLoRAAdvanced(ControlNetAdvanced):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.preprocess_image = lambda a: (a + 1) / 2.0
         self.require_vae = True
         self.mult_by_ratio_when_vae = False
 
@@ -212,7 +213,7 @@ def load_lora_data(control: CtrLoRAAdvanced, lora_path: str, loaded_data: dict[s
     # lora will do mm of up and down tensors
     for down_key in data_lora:
         # only process lora down keys; we will process both up+down at the same time
-        if ".up." in key:
+        if ".up." in down_key:
             continue
         # get up version of down key
         up_key = down_key.replace(".down.", ".up.")


### PR DESCRIPTION
Thank you for your excellent work on CtrLoRA. This pull request is to fix the preprocessor for the input condition. 

The VAE preprocesses the condition image from the range of [0, 1] to [-1, 1] (see https://github.com/comfyanonymous/ComfyUI/blob/ff838657fac787a0e7aef6bbbf92ea4411bdbd15/comfy/sd.py#L258). But in CtrLoRA, the input range of VAE is set to be [0, 1], so we should use an inverse transform to maintain the correct range (see the diff code).

An incorrect range affects the color, especially for the "palette" condition.

Before fixing, the results are not correct for the "palette" condition.
![image](https://github.com/user-attachments/assets/7eb0ab99-4226-45c3-8894-67105799d79a)

After fixing, the results well follow the "palette" condition, which is very close to the results from the official Gradio UI.
![image](https://github.com/user-attachments/assets/c0546484-e645-45b4-af76-6211835c3b0a)
