### PR TITLE
Apply fix for ControlNet conditioning to match changes from ComfyUI lowering VRAM usage

### DIFF
--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -3,6 +3,7 @@ from torch import Tensor
 import torch
 import os
 
+import comfy.model_base
 import comfy.ops
 import comfy.utils
 import comfy.model_management
@@ -108,13 +109,13 @@ class ControlNetAdvanced(ControlNet, AdvancedControlBase):
         for c in self.extra_conds:
             temp = cond.get(c, None)
             if temp is not None:
-                extra[c] = temp.to(dtype)
+                extra[c] = comfy.model_base.convert_tensor(temp, dtype, x_noisy.device)
 
         timestep = self.model_sampling_current.timestep(t)
         x_noisy = self.model_sampling_current.calculate_input(t, x_noisy)
         self.x_noisy_shape = x_noisy.shape
 
-        control = self.control_model(x=x_noisy.to(dtype), hint=self.cond_hint, timesteps=timestep.to(dtype), context=context.to(dtype), **extra)
+        control = self.control_model(x=x_noisy.to(dtype), hint=self.cond_hint, timesteps=timestep.to(dtype), context=comfy.model_management.cast_to_device(context, x_noisy.device, dtype), **extra)
         return self.control_merge(control, control_prev, output_dtype=None)
 
     def pre_run_advanced(self, *args, **kwargs):


### PR DESCRIPTION
Recently ComfyUI has refactored its code to lower VRAM usage, which has affected ControlNet flow.

Changes can be found at: [Lower cond vram use by casting at the same time as device transfer.](https://github.com/comfyanonymous/ComfyUI/commit/182f90b5eca2baa25474223759039925b286d562)

I've ported their fix to this node pack: [Fix broken controlnet from last PR.](https://github.com/comfyanonymous/ComfyUI/commit/140ffc7fdc53e810030f060e421c1f528c2d2ab9)

I applied my changes and tests to what seemingly is so far my use case, but this may potentially be needed at line 466 as well.