### PR TITLE
fix: update cast_bias_weight to use offloadable=True in clean_groupnorm

### DIFF
--- a/adv_control/utils.py
+++ b/adv_control/utils.py
@@ -338,8 +338,10 @@ class AbstractPreprocWrapper:
 class disable_weight_init_clean_groupnorm(comfy.ops.disable_weight_init):
     class GroupNorm(comfy.ops.disable_weight_init.GroupNorm):
         def forward_comfy_cast_weights(self, input):
-            weight, bias = comfy.ops.cast_bias_weight(self, input)
-            return torch.nn.functional.group_norm(input, self.num_groups, weight, bias, self.eps)
+            weight, bias, offload_stream = comfy.ops.cast_bias_weight(self, input, offloadable=True)
+            x = torch.nn.functional.group_norm(input, self.num_groups, weight, bias, self.eps)
+            comfy.ops.uncast_bias_weight(self, weight, bias, offload_stream)
+            return x
 
         def forward(self, input):
             if self.comfy_cast_weights:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-advanced-controlnet"
 description = "Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks."
-version = "1.5.6"
+version = "1.5.7"
 license = { file = "LICENSE" }
 dependencies = []
 
@@ -13,3 +13,4 @@ Repository = "https://github.com/Kosinkadink/ComfyUI-Advanced-ControlNet"
 PublisherId = "kosinkadink"
 DisplayName = "ComfyUI-Advanced-ControlNet"
 Icon = ""
+requires-comfyui = ">=0.3.68"


### PR DESCRIPTION
ComfyUI's `cast_bias_weight` now returns 3 values `(weight, bias, offload_stream)` when called with `offloadable=True`, and the old 2-value return is a legacy path. This updates `disable_weight_init_clean_groupnorm.GroupNorm.forward_comfy_cast_weights` to use the current API and call `uncast_bias_weight` after use for proper async-offload support.

Without this fix, the 2-value unpack causes `ValueError: too many values to unpack (expected 2)` on recent ComfyUI versions.