### PR TITLE
feat: add chenkincontrol ControlNet++ support with auto model detection

### DIFF
--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -15,6 +15,7 @@ from comfy.model_patcher import ModelPatcher
 from .control_sparsectrl import SparseControlNet, SparseSettings, SparseConst, InterfaceAnimateDiffModel, create_sparse_modelpatcher, load_sparsectrl_motionmodel
 from .control_lllite import LLLiteModule, LLLitePatch, load_controllllite
 from .control_svd import svd_unet_config_from_diffusers_unet, SVDControlNet, svd_unet_to_diffusers
+from .control_plusplus import load_controlnetplusplus
 from .utils import (AdvancedControlBase, TimestepKeyframeGroup, LatentKeyframeGroup, AbstractPreprocWrapper, ControlWeightType, ControlWeights, WeightTypeException, Extras,
                     manual_cast_clean_groupnorm, disable_weight_init_clean_groupnorm, WrapperConsts, prepare_mask_batch, get_properly_arranged_t2i_weights, load_torch_file_with_dict_factory,
                     broadcast_image_to_extend, extend_to_batch_size, ORIG_PREVIOUS_CONTROLNET, CONTROL_INIT_BY_ACN)
@@ -537,7 +538,8 @@ def load_controlnet(ckpt_path, timestep_keyframe: TimestepKeyframeGroup=None, mo
             has_temporal_res_block_key = True
         # ControlNet++ check
         elif "task_embedding" in key:
-            pass
+            controlnet_type = ControlWeightType.CONTROLNETPLUSPLUS
+            break
         # CtrLoRA check
         elif "lora_layer" in key:
             controlnet_type = ControlWeightType.CTRLORA
@@ -557,6 +559,8 @@ def load_controlnet(ckpt_path, timestep_keyframe: TimestepKeyframeGroup=None, mo
             control = load_svdcontrolnet(ckpt_path, controlnet_data=controlnet_data, timestep_keyframe=timestep_keyframe)
         elif controlnet_type == ControlWeightType.CTRLORA:
             raise Exception("This is a CtrLoRA; use the Load CtrLoRA Model node.")
+        elif controlnet_type == ControlWeightType.CONTROLNETPLUSPLUS:
+            control = load_controlnetplusplus(ckpt_path, timestep_keyframe=timestep_keyframe)
     # otherwise, load vanilla ControlNet
     else:
         try:

--- a/adv_control/control_plusplus.py
+++ b/adv_control/control_plusplus.py
@@ -11,6 +11,7 @@ from collections import OrderedDict
 
 
 from comfy.ldm.modules.diffusionmodules.util import (zero_module, timestep_embedding)
+from comfy.ldm.modules.diffusionmodules.openaimodel import TimestepEmbedSequential
 
 from comfy.cldm.cldm import ControlNet as ControlNetCLDM
 import comfy.cldm.cldm
@@ -37,10 +38,11 @@ class PlusPlusType:
     SEGMENT = "segment"
     TILE = "tile"
     REPAINT = "inpaint/outpaint"
+    FUSE = "fuse (chenkincontrol-only)"
     NONE = "none"
-    _LIST_WITH_NONE = [OPENPOSE, DEPTH, THICKLINE, THINLINE, NORMAL, SEGMENT, TILE, REPAINT, NONE]
-    _LIST = [OPENPOSE, DEPTH, THICKLINE, THINLINE, NORMAL, SEGMENT, TILE, REPAINT]
-    _DICT = {OPENPOSE: 0, DEPTH: 1, THICKLINE: 2, THINLINE: 3, NORMAL: 4, SEGMENT: 5, TILE: 6, REPAINT: 7, NONE: -1}
+    _LIST_WITH_NONE = [OPENPOSE, DEPTH, THICKLINE, THINLINE, NORMAL, SEGMENT, TILE, REPAINT, FUSE, NONE]
+    _LIST = [OPENPOSE, DEPTH, THICKLINE, THINLINE, NORMAL, SEGMENT, TILE, REPAINT, FUSE]
+    _DICT = {OPENPOSE: 0, DEPTH: 1, THICKLINE: 2, THINLINE: 3, NORMAL: 4, SEGMENT: 5, TILE: 6, REPAINT: 7, FUSE: 8, NONE: -1}
 
     @classmethod
     def to_idx(cls, control_type: str):
@@ -221,6 +223,35 @@ class ControlNetPlusPlus(ControlNetCLDM):
         out_middle.append(self.middle_block_out(h, emb, context))
 
         return {"middle": out_middle, "output": out_output}
+
+
+class ControlNetPlusPlusChenkin(ControlNetPlusPlus):
+    """chenkincontrol-only variant: wider input_hint_block channels [48, 96, 192, 384]."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        operations: comfy.ops.disable_weight_init = kwargs.get("operations", comfy.ops.disable_weight_init)
+        device = kwargs.get("device", None)
+        dims = 2
+        hint_channels = kwargs.get("hint_channels", 3)
+        c0, c1, c2, c3 = 48, 96, 192, 384
+        self.input_hint_block = TimestepEmbedSequential(
+            operations.conv_nd(dims, hint_channels, c0, 3, padding=1, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c0, c0, 3, padding=1, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c0, c1, 3, padding=1, stride=2, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c1, c1, 3, padding=1, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c1, c2, 3, padding=1, stride=2, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c2, c2, 3, padding=1, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c2, c3, 3, padding=1, stride=2, dtype=self.dtype, device=device),
+            nn.SiLU(),
+            operations.conv_nd(dims, c3, self.model_channels, 3, padding=1, dtype=self.dtype, device=device),
+        )
 
 
 class ControlNetPlusPlusAdvanced(ControlNet, AdvancedControlBase):
@@ -446,30 +477,40 @@ def load_controlnetplusplus(ckpt_path: str, timestep_keyframe: TimestepKeyframeG
     controlnet_config["dtype"] = unet_dtype
     controlnet_config.pop("out_channels")
     controlnet_config["hint_channels"] = controlnet_data["{}input_hint_block.0.weight".format(prefix)].shape[1]
-    control_model = ControlNetPlusPlus(**controlnet_config)
 
-    if pth:
-        if 'difference' in controlnet_data:
-            if model is not None:
-                comfy.model_management.load_models_gpu([model])
-                model_sd = model.model_state_dict()
-                for x in controlnet_data:
-                    c_m = "control_model."
-                    if x.startswith(c_m):
-                        sd_key = "diffusion_model.{}".format(x[len(c_m):])
-                        if sd_key in model_sd:
-                            cd = controlnet_data[x]
-                            cd += model_sd[sd_key].type(cd.dtype).to(cd.device)
-            else:
-                logger.warning("WARNING: Loaded a diff controlnet without a model. It will very likely not work.")
+    # Diff-controlnet side effects only depend on controlnet_data; apply once before trying model variants.
+    if pth and 'difference' in controlnet_data:
+        if model is not None:
+            comfy.model_management.load_models_gpu([model])
+            model_sd = model.model_state_dict()
+            for x in controlnet_data:
+                c_m = "control_model."
+                if x.startswith(c_m):
+                    sd_key = "diffusion_model.{}".format(x[len(c_m):])
+                    if sd_key in model_sd:
+                        cd = controlnet_data[x]
+                        cd += model_sd[sd_key].type(cd.dtype).to(cd.device)
+        else:
+            logger.warning("WARNING: Loaded a diff controlnet without a model. It will very likely not work.")
 
-        class WeightsLoader(torch.nn.Module):
-            pass
-        w = WeightsLoader()
-        w.control_model = control_model
-        missing, unexpected = w.load_state_dict(controlnet_data, strict=False)
-    else:
-        missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
+    def _load_with(cls):
+        m = cls(**controlnet_config)
+        if pth:
+            class WeightsLoader(torch.nn.Module):
+                pass
+            w = WeightsLoader()
+            w.control_model = m
+            miss, unexp = w.load_state_dict(controlnet_data, strict=False)
+        else:
+            miss, unexp = m.load_state_dict(controlnet_data, strict=False)
+        return m, miss, unexp
+
+    # Prefer chenkincontrol variant (wider input_hint_block); fall back to standard ControlNet++ on size mismatch.
+    try:
+        control_model, missing, unexpected = _load_with(ControlNetPlusPlusChenkin)
+    except RuntimeError as e:
+        logger.info("ControlNet++ chenkincontrol load failed ({}); falling back to standard ControlNet++.".format(e))
+        control_model, missing, unexpected = _load_with(ControlNetPlusPlus)
 
     if len(missing) > 0:
         logger.warning("missing ControlNet++ keys: {}".format(missing))

--- a/adv_control/nodes_plusplus.py
+++ b/adv_control/nodes_plusplus.py
@@ -1,6 +1,7 @@
 from torch import Tensor
 import math
 
+import comfy.utils
 import folder_paths
 
 from .control_plusplus import load_controlnetplusplus, PlusPlusType, PlusPlusInput, PlusPlusInputGroup, PlusPlusImageWrapper
@@ -47,9 +48,16 @@ class PlusPlusLoaderSingle:
 
     def load_controlnet_plusplus(self, name: str, control_type: str):
         controlnet_path = folder_paths.get_full_path("controlnet", name)
-        controlnet = load_controlnetplusplus(controlnet_path)
-        controlnet.single_control_type = control_type
-        controlnet.verify_control_type(name)
+        # Auto-detect: check for ControlNet++ signature
+        sd = comfy.utils.load_torch_file(controlnet_path, safe_load=True)
+        is_plusplus = any("task_embedding" in k for k in sd)
+        if is_plusplus:
+            controlnet = load_controlnetplusplus(controlnet_path)
+            controlnet.single_control_type = control_type
+            controlnet.verify_control_type(name)
+        else:
+            from .control import load_controlnet
+            controlnet = load_controlnet(controlnet_path)
         return (controlnet,)
 
 


### PR DESCRIPTION
Adds support for the chenkincontrol ControlNet++ variant (wider input_hint_block, FUSE control type) and auto-detects between chenkincontrol / standard ControlNet++ / vanilla ControlNet checkpoints in the loaders, switching to the correct path automatically.