### PR TITLE
Fix dtype mismatch for SparseCtrl and SVD-ControlNet models

### DIFF
--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -846,6 +846,10 @@ def load_sparsectrl(ckpt_path: str, controlnet_data: dict[str, Tensor]=None, tim
         missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
     if len(missing) > 0 or len(unexpected) > 0:
         logger.info(f"SparseCtrl ControlNet: {missing}, {unexpected}")
+    # cast control_model to the intended dtype; load_state_dict can leave weights
+    # in their on-disk dtype (e.g. comfy's lazy/zero-copy state dict loading), which
+    # would otherwise mismatch the activations at runtime
+    control_model = control_model.to(unet_dtype)
 
     global_average_pooling = False
     filename = os.path.splitext(ckpt_path)[0]
@@ -974,6 +978,10 @@ def load_svdcontrolnet(ckpt_path: str, controlnet_data: dict[str, Tensor]=None, 
         missing, unexpected = control_model.load_state_dict(controlnet_data, strict=False)
     if len(missing) > 0 or len(unexpected) > 0:
         logger.info(f"SVD-ControlNet: {missing}, {unexpected}")
+    # cast control_model to the intended dtype; load_state_dict can leave weights
+    # in their on-disk dtype (e.g. comfy's lazy/zero-copy state dict loading), which
+    # would otherwise mismatch the activations at runtime
+    control_model = control_model.to(unet_dtype)
 
     global_average_pooling = False
     filename = os.path.splitext(ckpt_path)[0]

--- a/adv_control/control.py
+++ b/adv_control/control.py
@@ -811,6 +811,7 @@ def load_sparsectrl(ckpt_path: str, controlnet_data: dict[str, Tensor]=None, tim
         controlnet_config["operations"] = manual_cast_clean_groupnorm
     else:
         controlnet_config["operations"] = disable_weight_init_clean_groupnorm
+    controlnet_config["dtype"] = unet_dtype
     controlnet_config.pop("out_channels")
     # get proper hint channels
     if use_simplified_conditioning_embedding:
@@ -944,6 +945,7 @@ def load_svdcontrolnet(ckpt_path: str, controlnet_data: dict[str, Tensor]=None, 
     manual_cast_dtype = comfy.model_management.unet_manual_cast(unet_dtype, load_device)
     if manual_cast_dtype is not None:
         controlnet_config["operations"] = comfy.ops.manual_cast
+    controlnet_config["dtype"] = unet_dtype
     controlnet_config.pop("out_channels")
     controlnet_config["hint_channels"] = controlnet_data["{}input_hint_block.0.weight".format(prefix)].shape[1]
     control_model = SVDControlNet(**controlnet_config)


### PR DESCRIPTION
## Problem

Using SparseCtrl (e.g. with AnimateDiff) raises at sampling time:

```
RuntimeError: mat1 and mat2 must have the same dtype, but got Half and Float
```

## Root cause

`load_sparsectrl` / `load_svdcontrolnet` build the control model but the loaded weights end up float32 while the UNet runs in fp16. Two things combine:

1. The `controlnet_config` for the non-diffusers (`.pth`/`.ckpt`) path comes from `model_config_from_unet(...).unet_config`, which has no `dtype` key, so the model is constructed with `dtype=None`.
2. More importantly, comfy's lazy/zero-copy `state_dict` loading (the Windows + aimdo path in `disable_weight_init._lazy_load_from_state_dict`) assigns the on-disk fp32 tensors **directly** as parameters and ignores the configured dtype. Because SparseCtrl/SVD use `disable_weight_init` ops (no runtime weight casting when `manual_cast_dtype is None`), the control model then runs fp32 weights against fp16 activations and fails at the first `time_embed` Linear.

This was exposed by newer ComfyUI model management; it doesn't coerce these control-model weights to a consistent dtype anymore.

## Fix

Two parts:

- Set `controlnet_config["dtype"] = unet_dtype` before building the model (matches the ControlNet++ / CtrLoRA loaders and comfy's own `load_controlnet_state_dict`), so `control_model.dtype` reports the correct compute dtype.
- Explicitly cast the control model to `unet_dtype` after `load_state_dict` (mirroring the motion-model load and AnimateDiff-Evolved #573), so the parameter tensors actually match the activation dtype regardless of how the state dict was loaded.

Note: this is distinct from AnimateDiff-Evolved #573, which fixed the SparseCtrl *motion* model dtype; this PR fixes the SparseCtrl/SVD *control* model dtype.

## Verification

Reproduced and fixed end-to-end via comfy-runner on an fp16 SD1.5 model with `v3_sd15_sparsectrl_rgb.ckpt` (a `.pth`-format SparseCtrl):

- **Before** (`origin/main`): KSampler raises `RuntimeError: mat1 and mat2 must have the same dtype, but got Half and Float` (traceback ends at `control_sparsectrl.py` `time_embed`).
- **After** (this branch): workflow completes, 8 frames generated, no error.

Fixes Kosinkadink/ComfyUI-AnimateDiff-Evolved#574