### PR TITLE
Bump version to 1.5.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-advanced-controlnet"
 description = "Nodes for scheduling ControlNet strength across timesteps and batched latents, as well as applying custom weights and attention masks."
-version = "1.5.7"
+version = "1.5.8"
 license = { file = "LICENSE" }
 dependencies = []
 


### PR DESCRIPTION
## Summary

- bump the package patch version from 1.5.7 to 1.5.8
- publish the SparseCtrl/SVD dtype fixes merged in #249

## Validation

- parsed `pyproject.toml` with Python `tomllib`
- ran `git diff --check`